### PR TITLE
Extension for Rational Bezier Splines

### DIFF
--- a/gustaf/__init__.py
+++ b/gustaf/__init__.py
@@ -11,7 +11,7 @@ from gustaf import io
 
 try:
     from gustaf import spline
-    from gustaf.spline.base import BSpline, NURBS, Bezier
+    from gustaf.spline.base import BSpline, NURBS, Bezier, RationalBezier
 except:
     spline = "cannot import spline modules"
 

--- a/gustaf/_base.py
+++ b/gustaf/_base.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from gustaf import utils
 
-class GustavBase(abc.ABC):
+class GustafBase(abc.ABC):
     """
     Base class for gustaf, where logging is nicely wrapped, and some useful
     methods are defined as classmethods..

--- a/gustaf/show.py
+++ b/gustaf/show.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from gustaf import settings
 from gustaf import utils
-from gustaf._base import GustavBase
+from gustaf._base import GustafBase
 
 # @linux it raises error if vedo is imported inside the function.
 try:
@@ -126,7 +126,7 @@ def show_vedo(*args, **kwargs,):
         to_pop = []
         to_extend = []
         for j, sl in enumerate(showlist):
-            if isinstance(sl, GustavBase):
+            if isinstance(sl, GustafBase):
                 tmp_showable = sl.showable(backend="vedo")
                 # splines return dict
                 # - maybe it is time to do some typing..

--- a/gustaf/spline/base.py
+++ b/gustaf/spline/base.py
@@ -441,6 +441,42 @@ class Bezier(GustavSpline, splinepy.Bezier):
         self._proximity = _Proximity(self)
 
 
+class RationalBezier(GustavSpline, splinepy.RationalBezier):
+
+    def __init__(
+            self,
+            degrees=None,
+            control_points=None,
+            weights=None,
+    ):
+        """
+        BSpline of gustaf. Inherited from splinepy.BSpline and GustavSpline.
+
+        Attributes
+        -----------
+        extract: _Extractor
+
+        Parameters
+        -----------
+        degrees: (para_dim,) list-like
+        knot_vectors: (para_dim, ...) list
+        control_points: (m, dim) list-like
+        weights : (m) list-like
+
+        Returns
+        --------
+        None
+        """
+        super(splinepy.RationalBezier, self).__init__(
+            degrees=degrees,
+            control_points=control_points,
+            weights=weights
+        )
+
+        self._extractor = _Extractor(self)
+        self._proximity = _Proximity(self)
+
+
 class BSpline(GustavSpline, splinepy.BSpline):
 
     def __init__(

--- a/gustaf/spline/base.py
+++ b/gustaf/spline/base.py
@@ -8,10 +8,11 @@ import abc
 
 import splinepy
 import numpy as np
+import logging
 
 from gustaf import settings
 from gustaf import show as showmodule
-from gustaf._base import GustavBase
+from gustaf._base import GustafBase
 from gustaf.vertices import Vertices
 from gustaf.spline.extract import _Extractor
 from gustaf.spline.proximity import _Proximity
@@ -276,7 +277,7 @@ def show(
         return plt
 
 
-class GustavSpline(GustavBase):
+class GustafSpline(GustafBase):
 
     @abc.abstractmethod
     def __init__(self):
@@ -408,7 +409,7 @@ class GustavSpline(GustavBase):
         return type(self)(**self.todict())
 
 
-class Bezier(GustavSpline, splinepy.Bezier):
+class Bezier(GustafSpline, splinepy.Bezier):
 
     def __init__(
             self,
@@ -416,7 +417,7 @@ class Bezier(GustavSpline, splinepy.Bezier):
             control_points=None,
     ):
         """
-        BSpline of gustaf. Inherited from splinepy.BSpline and GustavSpline.
+        Bezier of gustaf. Inherited from splinepy.Bezier and GustafSpline.
 
         Attributes
         -----------
@@ -425,7 +426,6 @@ class Bezier(GustavSpline, splinepy.Bezier):
         Parameters
         -----------
         degrees: (para_dim,) list-like
-        knot_vectors: (para_dim, ...) list
         control_points: (m, dim) list-like
 
         Returns
@@ -440,8 +440,45 @@ class Bezier(GustavSpline, splinepy.Bezier):
         self._extractor = _Extractor(self)
         self._proximity = _Proximity(self)
 
+    @property
+    def bspline(self):
+        """
+        Returns same parametric representation as BSpline.
 
-class RationalBezier(GustavSpline, splinepy.RationalBezier):
+        Parameters
+        -----------
+        None
+
+        Returns
+        --------
+        same_bspline : BSpline
+        """
+        return BSpline(
+            degrees=self.degrees,
+            control_points=self.control_points,
+            knot_vectors=[
+              [0] * (self.degrees[i] + 1) + [1] * (self.degrees[i] + 1)
+              for i in range(self.para_dim)]
+          )
+    
+    @property
+    def nurbs(self):
+        """
+        Returns same parametric representation as nurbs.
+
+        Parameters
+        -----------
+        None
+
+        Returns
+        --------
+        same_nurbs: NURBS
+        """
+        return self.bspline.nurbs
+
+
+
+class RationalBezier(GustafSpline, splinepy.RationalBezier):
 
     def __init__(
             self,
@@ -450,7 +487,8 @@ class RationalBezier(GustavSpline, splinepy.RationalBezier):
             weights=None,
     ):
         """
-        BSpline of gustaf. Inherited from splinepy.BSpline and GustavSpline.
+        Rational Bezier of gustaf. Inherited from splinepy.RationalBezier and
+        GustafSpline.
 
         Attributes
         -----------
@@ -459,7 +497,6 @@ class RationalBezier(GustavSpline, splinepy.RationalBezier):
         Parameters
         -----------
         degrees: (para_dim,) list-like
-        knot_vectors: (para_dim, ...) list
         control_points: (m, dim) list-like
         weights : (m) list-like
 
@@ -476,8 +513,30 @@ class RationalBezier(GustavSpline, splinepy.RationalBezier):
         self._extractor = _Extractor(self)
         self._proximity = _Proximity(self)
 
+    @property
+    def nurbs(self):
+        """
+        Returns same parametric representation as nurbs.
 
-class BSpline(GustavSpline, splinepy.BSpline):
+        Parameters
+        -----------
+        None
+
+        Returns
+        --------
+        same_nurbs: NURBS
+        """
+        return BSpline(
+            degrees=self.degrees,
+            control_points=self.control_points,
+            knot_vectors=[
+              [0] * (self.degrees[i] + 1) + [1] * (self.degrees[i] + 1)
+              for i in range(self.para_dim)],
+            weights=self.weights
+          )
+
+
+class BSpline(GustafSpline, splinepy.BSpline):
 
     def __init__(
             self,
@@ -486,7 +545,7 @@ class BSpline(GustavSpline, splinepy.BSpline):
             control_points=None,
     ):
         """
-        BSpline of gustaf. Inherited from splinepy.BSpline and GustavSpline.
+        BSpline of gustaf. Inherited from splinepy.BSpline and GustafSpline.
 
         Attributes
         -----------
@@ -535,8 +594,27 @@ class BSpline(GustavSpline, splinepy.BSpline):
             weights=np.ones(self.control_points.shape[0], dtype="float64")
         )
 
+    def extrac_bezier_patches(self):
+      """
+      Overwrites splinepy-parent's function to ensure the conversion of Splines
+      into a usable gustaf format
+      
+      Parameters
+      ----------
+      None
 
-class NURBS(GustavSpline, splinepy.NURBS):
+      Returns
+      -------
+      None
+      """
+      logging.warning(
+          "Functionality not supported, please use:\n"
+          "<BSpline>.extract.beziers()"
+      )
+      return None
+
+
+class NURBS(GustafSpline, splinepy.NURBS):
 
     def __init__(
             self,
@@ -599,6 +677,25 @@ class NURBS(GustavSpline, splinepy.NURBS):
         )
 
         return gustaf2mfem, mfem2gustaf
+
+    def extrac_bezier_patches(self):
+      """
+      Overwrites splinepy-parent's function to ensure the conversion of Splines
+      into a usable gustaf format
+      
+      Parameters
+      ----------
+      None
+
+      Returns
+      -------
+      None
+      """
+      logging.warning(
+          "Functionality not supported, please use:\n"
+          "<Nurbs>.extract.beziers()"
+      )
+      return None
 
 
 def from_mfem(nurbs_dict):

--- a/gustaf/spline/base.py
+++ b/gustaf/spline/base.py
@@ -5,10 +5,10 @@ Contains show and inherited classes from `spline`.
 """
 
 import abc
+import logging
 
 import splinepy
 import numpy as np
-import logging
 
 from gustaf import settings
 from gustaf import show as showmodule
@@ -693,7 +693,7 @@ class NURBS(GustafSpline, splinepy.NURBS):
       """
       logging.warning(
           "Functionality not supported, please use:\n"
-          "<Nurbs>.extract.beziers()"
+          "<NURBS>.extract.beziers()"
       )
       return None
 

--- a/gustaf/spline/base.py
+++ b/gustaf/spline/base.py
@@ -594,7 +594,7 @@ class BSpline(GustafSpline, splinepy.BSpline):
             weights=np.ones(self.control_points.shape[0], dtype="float64")
         )
 
-    def extrac_bezier_patches(self):
+    def extract_bezier_patches(self):
       """
       Overwrites splinepy-parent's function to ensure the conversion of Splines
       into a usable gustaf format
@@ -678,7 +678,7 @@ class NURBS(GustafSpline, splinepy.NURBS):
 
         return gustaf2mfem, mfem2gustaf
 
-    def extrac_bezier_patches(self):
+    def extract_bezier_patches(self):
       """
       Overwrites splinepy-parent's function to ensure the conversion of Splines
       into a usable gustaf format

--- a/gustaf/spline/extract.py
+++ b/gustaf/spline/extract.py
@@ -403,12 +403,13 @@ def beziers(spline):
   ----------
   spline : Gustaf-Spline
     """
+  from gustaf.spline.base import Bezier, RationalBezier
   if "Bezier" in spline.whatami:
       return spline
   elif "BSpline" in spline.whatami:
       return [Bezier(**s.todict()) 
           for s in super(type(spline), spline).extract_bezier_patches()]
-  elif "Nurbs" in spline.whatami:
+  elif "NURBS" in spline.whatami:
       return [RationalBezier(**s.todict()) 
           for s in super(type(spline), spline).extract_bezier_patches()]
   else:

--- a/gustaf/spline/extract.py
+++ b/gustaf/spline/extract.py
@@ -404,16 +404,21 @@ def beziers(spline):
   spline : Gustaf-Spline
     """
   from gustaf.spline.base import Bezier, RationalBezier
+  
   if "Bezier" in spline.whatami:
       return spline
   elif "BSpline" in spline.whatami:
-      return [Bezier(**s.todict()) 
-          for s in super(type(spline), spline).extract_bezier_patches()]
+      return [
+          Bezier(**s.todict()) 
+          for s in super(type(spline), spline).extract_bezier_patches()
+      ]
   elif "NURBS" in spline.whatami:
-      return [RationalBezier(**s.todict()) 
-          for s in super(type(spline), spline).extract_bezier_patches()]
+      return [
+          RationalBezier(**s.todict()) 
+          for s in super(type(spline), spline).extract_bezier_patches()
+      ]
   else:
-      raise ValueError("Unknown Spline-Type.")
+      raise TypeError("Unknown Spline-Type.")
 
 
 class _Extractor:

--- a/gustaf/spline/extract.py
+++ b/gustaf/spline/extract.py
@@ -395,6 +395,25 @@ def control_mesh(spline,):
             "Supports 1 to 3."
         )
 
+def beziers(spline):
+  """
+  Extracts Bezier-type objects of any spline-type object
+
+  Parameters
+  ----------
+  spline : Gustaf-Spline
+    """
+  if "Bezier" in spline.whatami:
+      return spline
+  elif "BSpline" in spline.whatami:
+      return [Bezier(**s.todict()) 
+          for s in super(type(spline), spline).extract_bezier_patches()]
+  elif "Nurbs" in spline.whatami:
+      return [RationalBezier(**s.todict()) 
+          for s in super(type(spline), spline).extract_bezier_patches()]
+  else:
+      raise ValueError("Unknown Spline-Type.")
+
 
 class _Extractor:
     """
@@ -433,4 +452,7 @@ class _Extractor:
     
     def control_mesh(self):
         return control_mesh(self.spline)
+
+    def beziers(self):
+        return beziers(self.spline)
 

--- a/gustaf/vertices.py
+++ b/gustaf/vertices.py
@@ -10,9 +10,9 @@ import numpy as np
 from gustaf import settings
 from gustaf import utils
 from gustaf import show
-from gustaf._base import GustavBase
+from gustaf._base import GustafBase
 
-class Vertices(GustavBase):
+class Vertices(GustafBase):
 
     kind = "vertex"
 


### PR DESCRIPTION
# Extension for Rational Bezier Splines
| :warning: WARNING          |
|:---------------------------|
| This PR is blocked from PR   [Rational Bezier Splines in Splinepy](https://github.com/tataratat/splinepy/pull/20) |
## Related Issues
#10 relates to new implementation of rational splines from within bezman
## Description
This PR extends gustaf's splines with rational Bezier splines. It further facilitates the conversion between splines, as from now on Bezier type splines can be converted into their non-uniform counterparts from `SplineLib`. These types can similarly be converted into a list of patches of the underlying part using
```
<BSpline-object>.extract.beziers()
or
<NURBS-object>.extract.beziers()
```
For type-safety, the `extract_bezier_patches()` routine was overwritten in the gustaf spline implementation.

Other changes:
-`GustavBase` and `GustavSpline` were changed into `GustafBase`, `GustafSpline`, respectively
- Updated Documentation of Bezier Splines were some copy-paste errors occured

## Remaining Work
- Extend Export / IO routines from Bezman
