### PR TITLE
Edit unique

### DIFF
--- a/gustaf/edges.py
+++ b/gustaf/edges.py
@@ -157,11 +157,11 @@ class Edges(Vertices):
 
     def get_edges_unique_inverse(self):
         """
-        Returns ids that can be used to reconstruct sorted edges with unique
+        Returns ids that can be used to reconstruct edges with unique
         edges.
 
         Good to know:
-          mesh.edges_sorted == mesh.unique_edges[mesh.edges_unique_inverse]
+          mesh.edges == mesh.unique_edges[mesh.edges_unique_inverse]
 
         Parameters
         -----------

--- a/gustaf/edges.py
+++ b/gustaf/edges.py
@@ -129,8 +129,10 @@ class Edges(Vertices):
         )
 
         # unpack
-        self.edges_unique = unique_stuff[0]
+        #   set edges_unique with `edges`.
+        #   otherwise it'd be based on edges_sorted and it changes orientation
         self.edges_unique_id = unique_stuff[1].astype(settings.INT_DTYPE)
+        self.edges_unique = self.edges[self.edges_unique_id]
         self.edges_unique_inverse = unique_stuff[2].astype(settings.INT_DTYPE)
         self.edges_unique_count = unique_stuff[3].astype(settings.INT_DTYPE)
         self.outlines = self.edges_unique_id[self.edges_unique_count == 1]

--- a/gustaf/faces.py
+++ b/gustaf/faces.py
@@ -156,13 +156,14 @@ class Faces(Edges):
         )
 
         # unpack
-        self.faces_unique = unique_stuff[0]
+        #  set faces_unique with `faces` to avoid orientation change
         self.faces_unique_id = unique_stuff[1].astype(settings.INT_DTYPE)
+        self.faces_unique = self.faces[self.faces_unique_id]
         self.faces_unique_inverse = unique_stuff[2].astype(settings.INT_DTYPE)
         self.faces_unique_count = unique_stuff[3].astype(settings.INT_DTYPE)
         self.surfaces = self.faces_unique_id[self.faces_unique_count == 1]
 
-        return self.faces_unique
+        return self.faces[self.faces_unique_id]
 
     def get_faces_unique_id(self):
         """

--- a/gustaf/volumes.py
+++ b/gustaf/volumes.py
@@ -13,6 +13,11 @@ class Volumes(Faces):
 
     __slots__ = [
         "volumes",
+        "volumes_sorted",
+        "volumes_unique",
+        "volumes_unique_id",
+        "volumes_unique_inverse",
+        "volumes_unique_count",
     ]
 
     def __init__(
@@ -43,12 +48,6 @@ class Volumes(Faces):
                 elements,
                 settings.INT_DTYPE,
             )
-
-        #if volumes is not None or elements is not None:
-        #    if self.volumes.shape[1] == 4:
-        #        self.whatami = "tet"
-        #    elif self.volumes.shape[1] == 8:
-        #        self.whatami = "hexa"
 
     def process(
             self,
@@ -91,6 +90,86 @@ class Volumes(Faces):
         Alias to update_elements.
         """
         self.update_elements(*args, **kwargs)
+
+    def get_volumes_sorted(self):
+        """
+        Sort volumes along axis=1.
+
+        Parameters
+        -----------
+        None
+
+        Returns
+        --------
+        volumes_sorted: (volumes.shape) np.ndarray
+        """
+        self.volumes_sorted = self.volumes.copy()
+        self.volumes_sorted.sort(axis=1)
+
+        return self.volumes_sorted
+
+    def get_volumes_unique(self):
+        """
+        Returns unique volumes.
+
+        Parameters
+        -----------
+        None
+
+        Returns
+        --------
+        volumes_unique: (n, 4) or (n, 8) np.ndarray
+        """
+        unique_stuff = utils.arr.unique_rows(
+            self.get_volumes_sorted(),
+            return_index=True,
+            return_inverse=True,
+            return_counts=True,
+            dtype_name=settings.INT_DTYPE,
+        )
+
+        # unpack
+        #  set volumes_unique with `volumes` to avoid orientation change
+        self.volumes_unique_id = unique_stuff[1].astype(settings.INT_DTYPE)
+        self.volumes_unique = self.volumes[self.volumes_unique_id]
+        self.volumes_unique_inverse = unique_stuff[2].astype(
+            settings.INT_DTYPE
+        )
+        self.volumes_unique_count = unique_stuff[2].astype(settings.INT_DTYPE)
+
+        return self.volumes_unique
+
+    def get_volumes_unique_id(self):
+        """
+        Similar to faces_unique_id but for volumes.
+
+        Parameters
+        -----------
+        None
+
+        Returns
+        --------
+        volumes_unique: (n,) np.ndarray
+        """
+        _ = self.get_volumes_unique()
+
+        return self.volumes_unique_id
+
+    def get_volumes_unique_inverse(self,):
+        """
+        Similar to faces_unique_inverse but for volumes.
+
+        Parameters
+        -----------
+        None
+
+        Returns
+        --------
+        None
+        """
+        _ = self.get_volumes_unique()
+
+        return self.volumes_unique_inverse
 
     def tofaces(self, unique=True):
         """


### PR DESCRIPTION
# Overview
While checking #13, I've realized `toedges(unique=True)`/`tofaces(unique=True)` builds Edges/Faces with sorted connectivity, which results in changed orientation. This is clearly observable with hexa. This PR introduces following changes:
- `get_<connectivity>_unique()` won't change orientation of connectivity.
- added `*_unique_*` for `Volumes`

## Related Issue

## Description