### PR TITLE
io.nutils tool

### DIFF
--- a/gustaf/io/__init__.py
+++ b/gustaf/io/__init__.py
@@ -10,3 +10,4 @@ from gustaf.io import ioutils
 from gustaf.io import mfem
 from gustaf.io import meshio
 from gustaf.io import mixd
+from gustaf.io import nutils

--- a/gustaf/io/mixd.py
+++ b/gustaf/io/mixd.py
@@ -197,11 +197,6 @@ def export(mesh, fname, space_time=False):
         # But they aren't.
 
         boundaries = as_mrng(nbelem,mesh)
-#        boundaries = np.empty(mesh.elements().shape[0] * nbelem, dtype=int)
-#        boundaries[:] = -1
-#
-#        for i, belem_ids in enumerate(mesh.BC.values()):
-#            boundaries[belem_ids] = i + 1 # bid starts at 1
 
         for b in boundaries:
             bf.write(struct.pack(big_endian_int, b))
@@ -252,4 +247,5 @@ def as_mrng(nbelem,mesh):
 
     for i, belem_ids in enumerate(mesh.BC.values()):
         boundaries[belem_ids] = i + 1 # bid starts at 1
+
     return boundaries

--- a/gustaf/io/mixd.py
+++ b/gustaf/io/mixd.py
@@ -195,11 +195,13 @@ def export(mesh, fname, space_time=False):
         # init boundaries with -1, as it is the value for non-boundary.
         # alternatively, they could be (-1 * neighbor_elem_id).
         # But they aren't.
-        boundaries = np.empty(mesh.elements().shape[0] * nbelem, dtype=int)
-        boundaries[:] = -1
 
-        for i, belem_ids in enumerate(mesh.BC.values()):
-            boundaries[belem_ids] = i + 1 # bid starts at 1
+        boundaries = as_mrng(nbelem,mesh)
+#        boundaries = np.empty(mesh.elements().shape[0] * nbelem, dtype=int)
+#        boundaries[:] = -1
+#
+#        for i, belem_ids in enumerate(mesh.BC.values()):
+#            boundaries[belem_ids] = i + 1 # bid starts at 1
 
         for b in boundaries:
             bf.write(struct.pack(big_endian_int, b))
@@ -227,3 +229,27 @@ def export(mesh, fname, space_time=False):
 
         # signature
         infof.write("\n\n\n# MIXD generated using `gustaf`.\n")
+
+def as_mrng(nbelem,mesh):
+    """
+    Returns the mrng as np.array.
+    Supports triangle, (quadrilateral), tetrahedron, and (hexahedron).
+    Only tested for tri and tet.
+
+    Parameters
+    -----------
+    mesh: Faces or Volumes
+    nbelem: int
+      Number of participating elements
+
+    Returns
+    --------
+    boundaries : ndarray
+      The mrng-array.
+    """
+    boundaries = np.empty(mesh.elements().shape[0] * nbelem, dtype=int)
+    boundaries[:] = -1
+
+    for i, belem_ids in enumerate(mesh.BC.values()):
+        boundaries[belem_ids] = i + 1 # bid starts at 1
+    return boundaries

--- a/gustaf/io/mixd.py
+++ b/gustaf/io/mixd.py
@@ -185,18 +185,11 @@ def export(mesh, fname, space_time=False):
 
     # write bc
     with open(bc_file, "wb") as bf:
-        nbelem = 3
-
-        if whatami.startswith("quad") or whatami.startswith("tet"):
-            nbelem += 1
-        elif whatami.startswith("hexa"):
-            nbelem += 3
-
         # init boundaries with -1, as it is the value for non-boundary.
         # alternatively, they could be (-1 * neighbor_elem_id).
         # But they aren't.
 
-        boundaries = as_mrng(nbelem,mesh)
+        boundaries = make_mrng(mesh)
 
         for b in boundaries:
             bf.write(struct.pack(big_endian_int, b))
@@ -225,16 +218,14 @@ def export(mesh, fname, space_time=False):
         # signature
         infof.write("\n\n\n# MIXD generated using `gustaf`.\n")
 
-def as_mrng(nbelem,mesh):
+def make_mrng(mesh):
     """
-    Returns the mrng as np.array.
-    Supports triangle, (quadrilateral), tetrahedron, and (hexahedron).
-    Only tested for tri and tet.
+    Builds and return mrng array based on `mesh.BC`
+    Supports `Faces` and `Volumes`.
 
     Parameters
     -----------
     mesh: Faces or Volumes
-    nbelem: int
       Number of participating elements
 
     Returns
@@ -242,6 +233,16 @@ def as_mrng(nbelem,mesh):
     boundaries : ndarray
       The mrng-array.
     """
+
+    # determine number of subelements
+    whatami = mesh.get_whatami()
+    nbelem = 3
+
+    if whatami.startswith("quad") or whatami.startswith("tet"):
+        nbelem += 1
+    elif whatami.startswith("hexa"):
+        nbelem += 3
+
     boundaries = np.empty(mesh.elements().shape[0] * nbelem, dtype=int)
     boundaries[:] = -1
 

--- a/gustaf/io/nutils.py
+++ b/gustaf/io/nutils.py
@@ -1,0 +1,106 @@
+"""gustaf/gustaf/io/nutils.py
+io functions for nutils.
+"""
+
+import os
+import struct
+
+import numpy as np
+
+from gustaf.vertices import Vertices
+from gustaf.faces import Faces
+from gustaf.volumes import Volumes
+from gustaf.io.ioutils import abs_fname, check_and_makedirs
+from gustaf.utils import log
+from gustaf.io import mixd
+
+def load(fname):
+    npzfile = np.load(fname, allow_pickle=True)
+    nodes = npzfile['nodes']
+    cnodes = npzfile['cnodes']
+    coords = npzfile['coords']
+    tags = npzfile['tags'].item()
+    btags = npzfile['btags'].item()
+    ptags = npzfile['ptags'].item()
+
+
+
+    print(btags)
+
+#    return mesh
+
+def export(fname, mesh):
+    dic = to_nutils_simplex(mesh)
+
+    # prepare export location
+    fname = abs_fname(fname)
+    check_and_makedirs(fname)
+
+    np.savez(fname, nodes = dic['nodes'], cnodes = dic['cnodes'], coords = dic['coords'], tags = dic['tags'] , btags = dic['btags'], ptags = dic['ptags'])
+
+
+def to_nutils_simplex(mesh):
+    dic_to_nutils = dict()
+    dimension = 2
+    permutation = [1,2,0]
+
+    vertices = mesh.get_vertices_unique()
+    faces = mesh.get_faces()			
+    elements = faces
+    whatami = mesh.get_whatami()
+    
+    if whatami.startswith("tet"):
+        dimension = 3
+        permutation = [2,3,1,0]
+        volumes = mesh.volumes				
+        elements = volumes
+    
+    #Sort the Node IDs for each Element. In 2D, element = face. In 3D, element = volume.
+    elements_sorted = np.zeros(elements.shape)
+    sort_array = np.zeros(elements.shape)
+    
+    for index, row in enumerate(elements, start = 0):
+        elements_sorted[index] = np.sort(row)	
+        sort_array[index] = np.argsort(row)
+    elements_sorted = elements_sorted.astype(int)	
+    sort_array = sort_array.astype(int)
+
+    #Let`s get the Boundaries
+    bcs = dict()
+    bcs_in = mixd.as_mrng(dimension + 1,mesh)	
+    bcs_in = np.ndarray.reshape(bcs_in,(int(len(bcs_in)/(dimension + 1)),(dimension + 1)))			#this is the mrng file
+
+    bound_id = np.unique(bcs_in)
+    bound_id = bound_id[bound_id > 0]
+
+    #Reorder the mrng according to nutils permutation --> important: does not work if mien file is rotated.
+    bcs_in[:,:] = bcs_in[:,permutation]	#swap collumns
+        
+    #Let's reorder the mrng file with the sort_array
+    bcs_sorted = np.zeros(bcs_in.shape)	
+    for index, sorts in enumerate(sort_array, start = 0):
+        bcs_sorted[index] = bcs_in[index][sorts]
+    bcs_sorted = bcs_sorted.astype(int)
+        
+    for bi in bound_id:
+        temp = []
+        for elid, el in enumerate(bcs_sorted, start = 0):
+            for index, edge in enumerate(el, start = 0):
+                if bi == edge:
+                    temp.append([elid,index])
+        bcs.update(
+            {str(bi)		:	np.array(temp)}
+        )
+
+    dic_to_nutils.update(   
+        {   'nodes'     :   elements_sorted,
+            'cnodes'    :   elements_sorted,
+            'coords'    :   vertices,
+            'tags'      :   {},
+            'btags'     :   bcs	,
+            'ptags'     :   {}
+        }   
+    )
+
+    return dic_to_nutils
+

--- a/gustaf/io/nutils.py
+++ b/gustaf/io/nutils.py
@@ -37,7 +37,11 @@ def load(fname):
     # connec
     simplex = True
     connec = None
-    volume = True  #adaption nec
+
+    if vertices.shape[1]==2:
+        volume = False 
+    else:
+        volume = True
 
     try:
         connec = nodes
@@ -47,10 +51,7 @@ def load(fname):
     # reshape connec
     if connec is not None:
         ncol = int(3) if simplex and not volume else int(4)
-        ncol = int(8) if ncol == int(4) and volume and not simplex else ncol
-
         connec = connec.reshape(-1, ncol)
-
         mesh = Volumes(vertices, connec) if volume else Faces(vertices, connec)
 
     mesh.BC = btags
@@ -100,6 +101,7 @@ def to_nutils_simplex(mesh):
     faces = mesh.get_faces()			
     whatami = mesh.get_whatami()
 
+    #In 2D, element = face. In 3D, element = volume.
     if whatami.startswith("tri"):
         dimension = 2
         permutation = [1,2,0]
@@ -112,7 +114,7 @@ def to_nutils_simplex(mesh):
     else:
         raise TypeError('Only Triangle and Tetrahedrons are accepted.') 
     
-    #Sort the Node IDs for each Element. In 2D, element = face. In 3D, element = volume.
+    #Sort the Node IDs for each Element. 
     elements_sorted = np.zeros(elements.shape)
     sort_array = np.zeros(elements.shape)
     
@@ -130,10 +132,10 @@ def to_nutils_simplex(mesh):
     bound_id = np.unique(bcs_in)
     bound_id = bound_id[bound_id > 0]
 
-    #Reorder the mrng according to nutils permutation --> important: does not work if mien file is rotated.
-    bcs_in[:,:] = bcs_in[:,permutation]	#swap collumns
+    #Reorder the mrng according to nutils permutation: swap collumns
+    bcs_in[:,:] = bcs_in[:,permutation]	
         
-    #Let's reorder the mrng file with the sort_array
+    #Let's reorder the bcs file with the sort_array
     bcs_sorted = np.zeros(bcs_in.shape)	
     for index, sorts in enumerate(sort_array, start = 0):
         bcs_sorted[index] = bcs_in[index][sorts]

--- a/gustaf/io/nutils.py
+++ b/gustaf/io/nutils.py
@@ -81,10 +81,11 @@ def export(fname, mesh):
     np.savez(fname, **dic)
 
 
-
 def to_nutils_simplex(mesh):
     """
-    Converts a Gustaf_Mesh to a Dictionary, which can be interpreted by nutils.mesh.simplex(**to_nutils_simplex(mesh)). Only work for Triangles and Tetrahedrons!
+    Converts a Gustaf_Mesh to a Dictionary, which can be interpreted by 
+    nutils.mesh.simplex(**to_nutils_simplex(mesh)). Only work for 
+    Triangles and Tetrahedrons!
 
     Parameters
     -----------
@@ -95,10 +96,8 @@ def to_nutils_simplex(mesh):
     dic_to_nutils: dict
     """
 
-    dic_to_nutils = dict()
-
-    vertices = mesh.get_vertices_unique()
-    faces = mesh.get_faces()			
+    vertices = mesh.vertices
+    faces = mesh.get_faces()		
     whatami = mesh.get_whatami()
 
     #In 2D, element = face. In 3D, element = volume.
@@ -113,12 +112,14 @@ def to_nutils_simplex(mesh):
         elements = volumes     
     else:
         raise TypeError('Only Triangle and Tetrahedrons are accepted.') 
+
+    dic_to_nutils = dict()
     
     #Sort the Node IDs for each Element. 
     elements_sorted = np.zeros(elements.shape)
     sort_array = np.zeros(elements.shape)
     
-    for index, row in enumerate(elements, start = 0):
+    for index, row in enumerate(elements):
         elements_sorted[index] = np.sort(row)	
         sort_array[index] = np.argsort(row)
     elements_sorted = elements_sorted.astype(int)	
@@ -126,7 +127,7 @@ def to_nutils_simplex(mesh):
 
     #Let`s get the Boundaries
     bcs = dict()
-    bcs_in = mixd.as_mrng(dimension + 1,mesh)	
+    bcs_in = mixd.make_mrng(mesh)	
     bcs_in = np.ndarray.reshape(bcs_in,(int(len(bcs_in)/(dimension + 1)),(dimension + 1)))
 
     bound_id = np.unique(bcs_in)
@@ -137,14 +138,14 @@ def to_nutils_simplex(mesh):
         
     #Let's reorder the bcs file with the sort_array
     bcs_sorted = np.zeros(bcs_in.shape)	
-    for index, sorts in enumerate(sort_array, start = 0):
+    for index, sorts in enumerate(sort_array):
         bcs_sorted[index] = bcs_in[index][sorts]
     bcs_sorted = bcs_sorted.astype(int)
         
     for bi in bound_id:
         temp = []
-        for elid, el in enumerate(bcs_sorted, start = 0):
-            for index, edge in enumerate(el, start = 0):
+        for elid, el in enumerate(bcs_sorted):
+            for index, edge in enumerate(el):
                 if bi == edge:
                     temp.append([elid,index])
         bcs.update(


### PR DESCRIPTION
# new io.nutils


## Related issues
#7 relates to a new tool for gustaf - nutils conversions

## Description
This PR extends ```gustaf.io``` by a ```nutils``` tool. It can load and export simplex meshes (triangle and tetrahedron) from Gustaf to Nutils and vice versa. Functions can be called by

```
    load(fname)
    export(fname,mesh)
    to_nutils_simplex(mesh)
```
A ```io.mixd``` adaption was necessary. The new function ```as_mrng``` returns a mrng-like file.