### PR TITLE
Create New Splines by Extrusion and Revolution

### DIFF
--- a/gustaf/spline/__init__.py
+++ b/gustaf/spline/__init__.py
@@ -7,5 +7,6 @@ However, since create.spline does not rely on `splinepy`, it is not here.
 
 
 from gustaf.spline import base
+from gustaf.spline import create
 from gustaf.spline import extract
 from gustaf.spline.base import show, from_mfem, load_splines

--- a/gustaf/spline/base.py
+++ b/gustaf/spline/base.py
@@ -494,7 +494,7 @@ class Bezier(GustafSpline, splinepy.Bezier):
         return RationalBezier(
             degrees=self.degrees,
             control_points=self.control_points,
-            weights=np.ones(control_points.shape[0])
+            weights=np.ones(self.control_points.shape[0])
         )
 
     @property

--- a/gustaf/spline/base.py
+++ b/gustaf/spline/base.py
@@ -464,6 +464,40 @@ class Bezier(GustafSpline, splinepy.Bezier):
         self._creator = _Creator(self)
 
     @property
+    def bezier(self):
+        """
+        Returns same parametric representation as Bezier Spline
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        same : Bezier
+        """
+        return self.copy()
+
+    @property
+    def rationalbezier(self):
+        """
+        Returns same parametric representation as Rational Bezier Spline
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        same : RationalBezier
+        """
+        return RationalBezier(
+            degrees=self.degrees,
+            control_points=self.control_points,
+            weights=np.ones(control_points.shape[0])
+        )
+
+    @property
     def bspline(self):
         """
         Returns same parametric representation as BSpline.
@@ -538,6 +572,21 @@ class RationalBezier(GustafSpline, splinepy.RationalBezier):
         self._extractor = _Extractor(self)
         self._proximity = _Proximity(self)
         self._creator = _Creator(self)
+        
+    @property
+    def rationalbezier(self):
+        """
+        Returns same parametric representation as Rational Bezier Spline
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        same : RationalBezier
+        """
+        return self.copy()
 
     @property
     def nurbs(self):
@@ -598,6 +647,21 @@ class BSpline(GustafSpline, splinepy.BSpline):
         self._extractor = _Extractor(self)
         self._proximity = _Proximity(self)
         self._creator = _Creator(self)
+
+    @property
+    def bspline(self):
+        """
+        Returns same parametric representation as BSpline.
+
+        Parameters
+        -----------
+        None
+
+        Returns
+        --------
+        same_bspline : BSpline
+        """
+        return self.copy()
 
     @property
     def nurbs(self):
@@ -728,6 +792,21 @@ class NURBS(GustafSpline, splinepy.NURBS):
           "<NURBS>.extract.beziers()"
       )
       return None
+    
+    @property
+    def nurbs(self):
+        """
+        Returns same parametric representation as nurbs.
+
+        Parameters
+        -----------
+        None
+
+        Returns
+        --------
+        same_nurbs: NURBS
+        """
+        return self.copy()
 
 
 def from_mfem(nurbs_dict):

--- a/gustaf/spline/base.py
+++ b/gustaf/spline/base.py
@@ -14,6 +14,7 @@ from gustaf import settings
 from gustaf import show as showmodule
 from gustaf._base import GustafBase
 from gustaf.vertices import Vertices
+from gustaf.spline.create import _Creator
 from gustaf.spline.extract import _Extractor
 from gustaf.spline.proximity import _Proximity
 from gustaf.spline._utils import to_res_list
@@ -311,6 +312,25 @@ class GustafSpline(GustafBase):
         return self._extractor
 
     @property
+    def create(self):
+      """
+      Returns spline creator
+      Can be used to create new splines using geometric relations
+
+      Examples
+      --------
+      >>> prism = spline.create.extrude(axis=[1,4,1])
+
+      Parameters
+      ----------
+      None
+
+      Returns
+      spline._Creator
+      """
+      return self._creator
+
+    @property
     def proximity(self):
         """
         Returns spline proximity helper.
@@ -422,6 +442,8 @@ class Bezier(GustafSpline, splinepy.Bezier):
         Attributes
         -----------
         extract: _Extractor
+        create: _Creator
+        proximity: _Proximity
 
         Parameters
         -----------
@@ -439,6 +461,7 @@ class Bezier(GustafSpline, splinepy.Bezier):
 
         self._extractor = _Extractor(self)
         self._proximity = _Proximity(self)
+        self._creator = _Creator(self)
 
     @property
     def bspline(self):
@@ -493,6 +516,8 @@ class RationalBezier(GustafSpline, splinepy.RationalBezier):
         Attributes
         -----------
         extract: _Extractor
+        create: _Creator
+        proximity: _Proximity
 
         Parameters
         -----------
@@ -512,6 +537,7 @@ class RationalBezier(GustafSpline, splinepy.RationalBezier):
 
         self._extractor = _Extractor(self)
         self._proximity = _Proximity(self)
+        self._creator = _Creator(self)
 
     @property
     def nurbs(self):
@@ -550,6 +576,8 @@ class BSpline(GustafSpline, splinepy.BSpline):
         Attributes
         -----------
         extract: _Extractor
+        create: _Creator
+        proximity: _Proximity
 
         Parameters
         -----------
@@ -569,6 +597,7 @@ class BSpline(GustafSpline, splinepy.BSpline):
 
         self._extractor = _Extractor(self)
         self._proximity = _Proximity(self)
+        self._creator = _Creator(self)
 
     @property
     def nurbs(self):
@@ -629,6 +658,8 @@ class NURBS(GustafSpline, splinepy.NURBS):
         Attributes
         -----------
         extract: _Extractor
+        create: _Creator
+        proximity: _Proximity
 
         Parameters
         -----------
@@ -650,6 +681,7 @@ class NURBS(GustafSpline, splinepy.NURBS):
 
         self._extractor = _Extractor(self)
         self._proximity = _Proximity(self)
+        self._creator = _Creator(self)
 
 
     @property

--- a/gustaf/spline/create.py
+++ b/gustaf/spline/create.py
@@ -7,11 +7,10 @@ Create operations for spline geometries
 import itertools
 
 import numpy as np
-
 from splinepy._spline import _RequiredProperties
 
 from gustaf import utils
-
+from gustaf import settings
 
 def extrude(spline, extrusion_vector=None):
     """

--- a/gustaf/spline/create.py
+++ b/gustaf/spline/create.py
@@ -198,7 +198,7 @@ def revolve(spline,
         axis=axis,
         rotation=rot_a,
         degree=False
-                      ).T
+    ).T
 
     # Start Extrusion
     spline_dict = dict()

--- a/gustaf/spline/create.py
+++ b/gustaf/spline/create.py
@@ -36,17 +36,18 @@ def extrude(spline, axis=None):
     # formulate correct cps
     if spline.dim == axis.shape[0]:
         cps = spline.control_points
-    elif int(spline.dim + 1) == axis.shape[0]:
+    elif spline.dim > axis.shape[0]:
+        expansion_dimension = axis.shape - spline.dim
         # one smaller dim is allowed
         # warn that we assume new dim is all zero
         utils.log.warning(
-            "Given axis is one dimension bigger than spline's dim.",
-            "Assuming 0.0 entries for new dimension."
+            "Given axis is f{expansion_dimension} dimension bigger than "
+            "spline's dim. Assuming 0.0 entries for new dimension.",
         )
         cps = np.hstack(
             (
                 spline.control_points,
-                np.ones((len(spline.control_points), 1)
+                np.zeros((len(spline.control_points), expansion_dimension))
             )
         )
     else:

--- a/gustaf/spline/create.py
+++ b/gustaf/spline/create.py
@@ -59,16 +59,16 @@ def extrude(spline, extrusion_vector=None):
         )
 
     # Start Extrusion
-    arguments = {}
+    spline_dict = dict()
 
-    arguments["degrees"] = np.concatenate((spline.degrees, [1]))
-    arguments["control_points"] = np.vstack((cps, cps + extrusion_vector))
+    spline_dict["degrees"] = np.concatenate((spline.degrees, [1]))
+    spline_dict["control_points"] = np.vstack((cps, cps + extrusion_vector))
     if "knot_vectors" in _RequiredProperties.of(spline):
-        arguments["knot_vectors"] = spline.knot_vectors + [[0, 0, 1, 1]]
+        spline_dict["knot_vectors"] = spline.knot_vectors + [[0, 0, 1, 1]]
     if "weights" in _RequiredProperties.of(spline):
-        arguments["weights"] = np.concatenate((spline.weights, spline.weights))
+        spline_dict["weights"] = np.concatenate((spline.weights, spline.weights))
 
-    return type(spline)(**arguments)
+    return type(spline)(**spline_dict)
 
 
 def revolve(spline, axis=None, center=None, angle=None, n_knot_spans=None):
@@ -188,11 +188,11 @@ def revolve(spline, axis=None, center=None, angle=None, n_knot_spans=None):
         ).T
 
     # Start Extrusion
-    arguments = {}
+    spline_dict = dict()
 
-    arguments["degrees"] = np.concatenate((spline.degrees, [2]))
+    spline_dict["degrees"] = np.concatenate((spline.degrees, [2]))
 
-    arguments["control_points"] = cps
+    spline_dict["control_points"] = cps
     end_points = cps
     for i_segment in range(n_knot_spans):
         # Rotate around axis
@@ -204,8 +204,8 @@ def revolve(spline, axis=None, center=None, angle=None, n_knot_spans=None):
             mid_points = (mid_points - mp_scale) * factor + mp_scale
         else:
             mid_points *= factor
-        arguments["control_points"] = np.concatenate((
-            arguments["control_points"],
+        spline_dict["control_points"] = np.concatenate((
+            spline_dict["control_points"],
             mid_points,
             end_points
         ))
@@ -213,15 +213,15 @@ def revolve(spline, axis=None, center=None, angle=None, n_knot_spans=None):
     if "knot_vectors" in _RequiredProperties.of(spline):
         kv = [0, 0, 0]
         [kv.extend([i + 1, i + 1]) for i in range(n_knot_spans - 1)]
-        arguments["knot_vectors"] = spline.knot_vectors + [
+        spline_dict["knot_vectors"] = spline.knot_vectors + [
             kv + [n_knot_spans+1] * 3
         ]
     if "weights" in _RequiredProperties.of(spline):
         mid_weights = spline.weights * weight
-        arguments["weights"] = spline.weights
+        spline_dict["weights"] = spline.weights
         for i_segment in range(n_knot_spans):
-            arguments["weights"] = np.concatenate((
-                arguments["weights"],
+            spline_dict["weights"] = np.concatenate((
+                spline_dict["weights"],
                 mid_weights,
                 spline.weights
             ))
@@ -232,9 +232,9 @@ def revolve(spline, axis=None, center=None, angle=None, n_knot_spans=None):
         )
 
     if center is not None:
-        arguments["control_points"] += center
+        spline_dict["control_points"] += center
 
-    return type(spline)(**arguments)
+    return type(spline)(**spline_dict)
 
 
 class _Creator:

--- a/gustaf/spline/create.py
+++ b/gustaf/spline/create.py
@@ -184,7 +184,7 @@ def revolve(spline, axis=None, center=None, angle=None, n_knot_spans=None):
 
     if center is not None:
         spline.control_points += center
-        arguments.control_points += center
+        arguments["control_points"] += center
 
     return type(spline)(**arguments)
 

--- a/gustaf/spline/create.py
+++ b/gustaf/spline/create.py
@@ -1,0 +1,209 @@
+"""gustaf/spline/create.py
+
+Create operations for spline geometries
+"""
+
+
+import itertools
+import logging
+import numpy as np
+
+
+def extrude(spline, axis=None):
+    """
+    Extrudes Splines ype objects of any spline-type object
+
+    Parameters
+    ----------
+    spline : Gustaf-Spline
+    axis : Extrusion axis
+    """
+    from gustaf.spline.base import GustafSpline
+
+    # Check input type
+    from gustaf.spline.base import GustafSpline
+    if not issubclass(type(spline), GustafSpline):
+        raise NotImplementedError("Extrude only works for splines")
+
+    # Check axis
+    if axis is not None:
+        axis = np.asarray(axis)
+        if len(axis.shape) == 0:
+            axis = np.asarray([axis])
+    else:
+        raise ValueError("No extrusion Axis given")
+
+    # Check Axis dimension
+    if not (spline.control_points.shape[1] == axis.shape[0]):
+        raise ValueError(
+            "Dimension Mismatch between extrusion axis and spline."
+        )
+
+    # Start Extrusion
+    arguments = {}
+
+    arguments["degrees"] = np.concatenate((spline.degrees, [1]))
+    arguments["control_points"] = np.concatenate((
+        spline.control_points,
+        spline.control_points + axis))
+    if "knot_vectors" in spline._required_properties:
+        arguments["knot_vectors"] = spline.knot_vectors + [[0,0,1,1]]
+    if "weights" in spline._required_properties:
+        arguments["weights"] = np.concatenate((spline.weights, spline.weights))
+
+    return type(spline)(**arguments)
+
+def revolve(spline, axis=None, center=None, angle=None, n_knot_spans=None):
+    """
+    Revolve spline around an axis
+    """
+    from gustaf.spline.base import GustafSpline
+
+    # Check input type
+    if not issubclass(type(spline), GustafSpline):
+        raise NotImplementedError("Revolutions only works for splines")
+
+    # The parametric dimension is independent of the revolution but the
+    # rotation-matrix is only implemented for 2D and 3D problems
+    if not (spline.dim == 2 or spline.dim == 3):
+        raise NotImplementedError(
+            "Revolutions only implemented for 2D and 3D geometries"
+        )
+
+    # Check axis
+    if axis is not None:
+        axis = np.asarray(axis)
+        # Check Axis dimension
+        if not (spline.control_points.shape[1] == axis.shape[0]):
+            raise ValueError(
+                "Dimension Mismatch between extrusion axis and spline."
+            )
+        if spline.control_points.shape[1] == 2:
+            logging.warning("Axis argument for 2D rotation will be ignored")
+        # Make sure axis is normalized
+        axis = axis / np.linalg.norm(axis)
+    else:
+        if spline.control_points.shape[1] == 3:
+            raise ValueError("No rotation axis given")
+
+    # Init center
+    if center is not None:
+        center = np.asarray(axis)
+        # Check Axis dimension
+        if not (spline.control_points.shape[1] == center.shape[0]):
+            raise ValueError(
+                "Dimension Mismatch between extrusion center and spline."
+            )
+        spline.control_points -= center
+
+    # Angle must be (0, pi) non including
+    # Rotation is always performed in half steps
+    PI = np.pi
+    if n_knot_spans is None:
+        n_knot_spans = int(np.ceil(np.abs((angle + 1e-13) / PI)))
+    else:
+        if n_knot_spans < int(np.ceil(np.abs((angle + 1e-13) / PI))):
+            logging.warning(
+                f"Number of segments was insufficient "
+                "- raised to {n_knot_spans}"
+            )
+            n_knot_spans = int(np.ceil(np.abs((angle + 1e-13) / PI)))
+
+    if "Bezier" in spline.whatami:
+        if n_knot_spans > 1:
+            raise ValueError(
+                "Revolutions are only supported for angles up to 180 degrees"
+                "for Bezier type splines as they consist of only one knot span"
+            )
+
+    # Determine auxiliary values
+    rot_a = angle / (2 * n_knot_spans)
+    half_counter_angle = PI / 2 - rot_a
+    weight = np.sin(half_counter_angle)
+    factor = 1 / weight
+
+
+    # Assemble rotation matrix
+    if spline.dim == 2:
+        rotation_matrix = np.array([
+            [np.cos(rot_a), -np.sin(rot_a)],
+            [np.sin(rot_a), np.cos(rot_a)]
+        ]).T
+    else:
+        # See rodrigues' formula
+        rotation_matrix = np.array(
+            [[0, -axis[2], axis[1]],
+            [axis[2], 0, -axis[0]],
+            [axis[1], axis[0], 0]]
+        )
+        rotation_matrix = (np.eye(3) + np.sin(rot_a) * rotation_matrix + (
+            (1 - np.cos(rot_a)) * np.matmul(rotation_matrix, rotation_matrix))
+            ).T
+
+    # Start Extrusion
+    arguments = {}
+
+    arguments["degrees"] = np.concatenate((spline.degrees, [2]))
+
+    arguments["control_points"] = spline.control_points
+    end_points = spline.control_points
+    for i_segment in range(n_knot_spans):
+        # Rotate around axis
+        mid_points = np.matmul(end_points, rotation_matrix)
+        end_points = np.matmul(mid_points, rotation_matrix)
+        # Move away from axis using dot-product tricks
+        mid_point_scale = axis * np.dot(mid_points, axis).reshape(-1,1)
+        mid_points = (mid_points - mid_point_scale) * factor + mid_point_scale
+        arguments["control_points"] = np.concatenate((
+            arguments["control_points"],
+            mid_points,
+            end_points
+        ))
+
+    if "knot_vectors" in spline._required_properties:
+        kv = [0,0,0]
+        [kv.extend([i + 1, i + 1]) for i in range(n_knot_spans - 1)]
+        arguments["knot_vectors"] = spline.knot_vectors + [
+            kv + [n_knot_spans+1] * 3
+        ]
+        print(kv)
+    if "weights" in spline._required_properties:
+        mid_weights = spline.weights * weight
+        arguments["weights"] = spline.weights
+        for i_segment in range(n_knot_spans):
+          arguments["weights"] = np.concatenate((
+              arguments["weights"],
+              mid_weights,
+              spline.weights
+          ))
+    else:
+        logging.warning(
+            "True revolutions are only possible for rational spline types.\n"
+            "Creating Approximation"
+        )
+
+    if center is not None:
+        spline.control_points += center
+        arguments.control_points += center
+
+    return type(spline)(**arguments)
+
+
+class _Creator:
+    """
+    Helper class to build new splines from existing geometries
+
+    Examples
+    ---------
+    >>> myspline = <your-spline>
+    >>> spline_faces = myspline.create.extrude(vector=[3,1,3])
+    """
+
+    def __init__(self, spl):
+        self.spline = spl
+
+    def extrude(self, *args, **kwargs):
+        return extrude(self.spline, *args, **kwargs)
+
+    def revolve(self, *args, **kwargs):
+        return revolve(self.spline, *args, **kwargs)

--- a/gustaf/spline/create.py
+++ b/gustaf/spline/create.py
@@ -12,6 +12,7 @@ from splinepy._spline import _RequiredProperties
 from gustaf import utils
 from gustaf import settings
 
+
 def extrude(spline, extrusion_vector=None):
     """
     Extrudes Splines
@@ -43,7 +44,7 @@ def extrude(spline, extrusion_vector=None):
         # one smaller dim is allowed
         # warn that we assume new dim is all zero
         utils.log.warning(
-            "Given extrusion vector is f{expansion_dimension} dimension bigger than "
+            f"Given extrusion vector is {expansion_dimension} dimension bigger than "
             "spline's dim. Assuming 0.0 entries for new dimension.",
         )
         cps = np.hstack(
@@ -65,7 +66,8 @@ def extrude(spline, extrusion_vector=None):
     if "knot_vectors" in _RequiredProperties.of(spline):
         spline_dict["knot_vectors"] = spline.knot_vectors + [[0, 0, 1, 1]]
     if "weights" in _RequiredProperties.of(spline):
-        spline_dict["weights"] = np.concatenate((spline.weights, spline.weights))
+        spline_dict["weights"] = np.concatenate(
+            (spline.weights, spline.weights))
 
     return type(spline)(**spline_dict)
 
@@ -121,7 +123,12 @@ def revolve(spline, axis=None, center=None, angle=None, n_knot_spans=None):
             cps = np.copy(spline.control_points)
 
         # Make sure axis is normalized
-        axis = axis / np.linalg.norm(axis)
+
+        axis_norm = np.linalg.norm(axis)
+        if not np.isclose(axis_norm, 0, atol=settings.TOLERANCE):
+            axis = axis / axis_norm
+        else:
+            raise ValueError("Axis-norm is too close to zero.")
     else:
         cps = np.copy(spline.control_points)
         if spline.control_points.shape[1] == 3:

--- a/gustaf/spline/create.py
+++ b/gustaf/spline/create.py
@@ -166,7 +166,6 @@ def revolve(spline, axis=None, center=None, angle=None, n_knot_spans=None):
         arguments["knot_vectors"] = spline.knot_vectors + [
             kv + [n_knot_spans+1] * 3
         ]
-        print(kv)
     if "weights" in spline._required_properties:
         mid_weights = spline.weights * weight
         arguments["weights"] = spline.weights

--- a/gustaf/spline/create.py
+++ b/gustaf/spline/create.py
@@ -5,43 +5,46 @@ Create operations for spline geometries
 
 
 import itertools
-import logging
 
 import numpy as np
 
+from splinepy._spline import _RequiredProperties
 
-def extrude(spline, axis=None):
+from gustaf import utils
+
+
+def extrude(spline, extrusion_vector=None):
     """
     Extrudes Splines
 
     Parameters
     ----------
     spline: GustafSpline
-    axis: np.ndarray
+    extrusion_vector: np.ndarray
     """
     from gustaf.spline.base import GustafSpline
-    
+
     # Check input type
     if not issubclass(type(spline), GustafSpline):
         raise NotImplementedError("Extrude only works for splines")
 
-    # Check axis
-    if axis is not None:
-        # make flat axis
-        axis = np.asarray(axis).ravel()
+    # Check extrusion_vector
+    if extrusion_vector is not None:
+        # make flat extrusion_vector
+        extrusion_vector = np.asarray(extrusion_vector).ravel()
     else:
-        raise ValueError("No extrusion Axis given")
+        raise ValueError("No extrusion extrusion_vector given")
 
-    # Check Axis dimension
+    # Check extrusion_vector dimension
     # formulate correct cps
-    if spline.dim == axis.shape[0]:
+    if spline.dim == extrusion_vector.shape[0]:
         cps = spline.control_points
-    elif spline.dim > axis.shape[0]:
-        expansion_dimension = axis.shape - spline.dim
+    elif spline.dim < extrusion_vector.shape[0]:
+        expansion_dimension = extrusion_vector.shape[0] - spline.dim
         # one smaller dim is allowed
         # warn that we assume new dim is all zero
         utils.log.warning(
-            "Given axis is f{expansion_dimension} dimension bigger than "
+            "Given extrusion vector is f{expansion_dimension} dimension bigger than "
             "spline's dim. Assuming 0.0 entries for new dimension.",
         )
         cps = np.hstack(
@@ -52,17 +55,17 @@ def extrude(spline, axis=None):
         )
     else:
         raise ValueError(
-            "Dimension Mismatch between extrusion axis and spline."
+            "Dimension Mismatch between extrusion extrusion vector and spline."
         )
 
     # Start Extrusion
     arguments = {}
 
     arguments["degrees"] = np.concatenate((spline.degrees, [1]))
-    arguments["control_points"] = np.vstack((cps, cps + axis))
-    if "knot_vectors" in spline._required_properties:
-        arguments["knot_vectors"] = spline.knot_vectors + [[0,0,1,1]]
-    if "weights" in spline._required_properties:
+    arguments["control_points"] = np.vstack((cps, cps + extrusion_vector))
+    if "knot_vectors" in _RequiredProperties.of(spline):
+        arguments["knot_vectors"] = spline.knot_vectors + [[0, 0, 1, 1]]
+    if "weights" in _RequiredProperties.of(spline):
         arguments["weights"] = np.concatenate((spline.weights, spline.weights))
 
     return type(spline)(**arguments)
@@ -94,54 +97,65 @@ def revolve(spline, axis=None, center=None, angle=None, n_knot_spans=None):
     if not issubclass(type(spline), GustafSpline):
         raise NotImplementedError("Revolutions only works for splines")
 
+    # Check axis
+    if axis is not None:
+        # Transform into numpy array
+        axis = np.asarray(axis).ravel()
+        # Check Axis dimension
+        if (spline.control_points.shape[1] > axis.shape[0]):
+            raise ValueError(
+                "Dimension Mismatch between extrusion axis and spline."
+            )
+        elif (spline.control_points.shape[1] < axis.shape[0]):
+            utils.log.warning(
+                "Control Point dimension is smaller than axis dimension,"
+                " filling with zeros"
+            )
+            expansion_dimension = axis.shape[0] - spline.dim
+            cps = np.hstack(
+                (
+                    spline.control_points,
+                    np.zeros((len(spline.control_points), expansion_dimension))
+                )
+            )
+        else:
+            cps = np.copy(spline.control_points)
+
+        # Make sure axis is normalized
+        axis = axis / np.linalg.norm(axis)
+    else:
+        cps = np.copy(spline.control_points)
+        if spline.control_points.shape[1] == 3:
+            raise ValueError("No rotation axis given")
+
+    # Set Problem dimension
+    problem_dimension = cps.shape[1]
+
+    # Init center
+    if center is not None:
+        center = np.asarray(center).ravel()
+        # Check Axis dimension
+        if not (problem_dimension == center.shape[0]):
+            raise ValueError(
+                "Dimension Mismatch between axis and center of rotation."
+            )
+        cps -= center
+
     # The parametric dimension is independent of the revolution but the
     # rotation-matrix is only implemented for 2D and 3D problems
-    if not (spline.dim == 2 or spline.dim == 3):
+    if not (cps.shape[1] == 2 or cps.shape[1] == 3):
         raise NotImplementedError(
             "Sorry,"
             "revolutions only implemented for 2D and 3D splines"
         )
 
-    # Check axis
-    if axis is not None:
-        if spline.dim == 2:
-            logging.warning("For 2D revolutions axis will be ignored")
-            axis=None
-        else:
-            axis = np.asarray(axis)
-            # Check Axis dimension
-            if not (spline.control_points.shape[1] == axis.shape[0]):
-                raise ValueError(
-                    "Dimension Mismatch between extrusion axis and spline."
-                )
-            # Make sure axis is normalized
-            axis = axis / np.linalg.norm(axis)
-    else:
-        if spline.control_points.shape[1] == 3:
-            raise ValueError("No rotation axis given")
-
-    # Init center
-    if center is not None:
-        center = np.asarray(axis)
-        # Check Axis dimension
-        if not (spline.control_points.shape[1] == center.shape[0]):
-            raise ValueError(
-                "Dimension Mismatch between extrusion center and spline."
-            )
-        spline.control_points -= center
-
     # Angle must be (0, pi) non including
     # Rotation is always performed in half steps
     PI = np.pi
-    if n_knot_spans is None:
-        n_knot_spans = int(np.ceil(np.abs((angle + 1e-13) / PI)))
-    else:
-        if n_knot_spans < int(np.ceil(np.abs((angle + 1e-13) / PI))):
-            logging.warning(
-                f"Number of segments was insufficient "
-                "- raised to {n_knot_spans}"
-            )
-            n_knot_spans = int(np.ceil(np.abs((angle + 1e-13) / PI)))
+    round_tolerance = 1e-13
+    minimum_n_knot_spans = int(np.ceil(np.abs((angle + round_tolerance) / PI)))
+    if (n_knot_spans) is None or (n_knot_spans < minimum_n_knot_spans):
+        n_knot_spans = minimum_n_knot_spans
 
     if "Bezier" in spline.whatami:
         if n_knot_spans > 1:
@@ -156,38 +170,37 @@ def revolve(spline, axis=None, center=None, angle=None, n_knot_spans=None):
     weight = np.sin(half_counter_angle)
     factor = 1 / weight
 
-
     # Assemble rotation matrix
-    if spline.dim == 2:
+    if problem_dimension == 2:
         rotation_matrix = np.array([
             [np.cos(rot_a), -np.sin(rot_a)],
             [np.sin(rot_a), np.cos(rot_a)]
         ]).T
     else:
-        # See rodrigues' formula
+        # See Rodrigues' formula
         rotation_matrix = np.array(
             [[0, -axis[2], axis[1]],
-            [axis[2], 0, -axis[0]],
-            [axis[1], axis[0], 0]]
+             [axis[2], 0, -axis[0]],
+             [axis[1], axis[0], 0]]
         )
         rotation_matrix = (np.eye(3) + np.sin(rot_a) * rotation_matrix + (
             (1 - np.cos(rot_a)) * np.matmul(rotation_matrix, rotation_matrix))
-            ).T
+        ).T
 
     # Start Extrusion
     arguments = {}
 
     arguments["degrees"] = np.concatenate((spline.degrees, [2]))
 
-    arguments["control_points"] = spline.control_points
-    end_points = spline.control_points
+    arguments["control_points"] = cps
+    end_points = cps
     for i_segment in range(n_knot_spans):
         # Rotate around axis
         mid_points = np.matmul(end_points, rotation_matrix)
         end_points = np.matmul(mid_points, rotation_matrix)
         # Move away from axis using dot-product tricks
-        if spline.dim == 3:
-            mp_scale = axis * np.dot(mid_points, axis).reshape(-1,1)
+        if problem_dimension == 3:
+            mp_scale = axis * np.dot(mid_points, axis).reshape(-1, 1)
             mid_points = (mid_points - mp_scale) * factor + mp_scale
         else:
             mid_points *= factor
@@ -197,29 +210,28 @@ def revolve(spline, axis=None, center=None, angle=None, n_knot_spans=None):
             end_points
         ))
 
-    if "knot_vectors" in spline._required_properties:
-        kv = [0,0,0]
+    if "knot_vectors" in _RequiredProperties.of(spline):
+        kv = [0, 0, 0]
         [kv.extend([i + 1, i + 1]) for i in range(n_knot_spans - 1)]
         arguments["knot_vectors"] = spline.knot_vectors + [
             kv + [n_knot_spans+1] * 3
         ]
-    if "weights" in spline._required_properties:
+    if "weights" in _RequiredProperties.of(spline):
         mid_weights = spline.weights * weight
         arguments["weights"] = spline.weights
         for i_segment in range(n_knot_spans):
-          arguments["weights"] = np.concatenate((
-              arguments["weights"],
-              mid_weights,
-              spline.weights
-          ))
+            arguments["weights"] = np.concatenate((
+                arguments["weights"],
+                mid_weights,
+                spline.weights
+            ))
     else:
-        logging.warning(
+        utils.log.warning(
             "True revolutions are only possible for rational spline types.\n"
             "Creating Approximation"
         )
 
     if center is not None:
-        spline.control_points += center
         arguments["control_points"] += center
 
     return type(spline)(**arguments)

--- a/gustaf/spline/create.py
+++ b/gustaf/spline/create.py
@@ -175,7 +175,8 @@ def revolve(spline,
     # Rotation is always performed in half steps
     PI = np.pi
     minimum_n_knot_spans = int(
-        np.ceil(np.abs((angle + settings.TOLERANCE) / PI)))
+        np.ceil(np.abs((angle + settings.TOLERANCE) / PI))
+    )
     if (n_knot_spans) is None or (n_knot_spans < minimum_n_knot_spans):
         n_knot_spans = minimum_n_knot_spans
 

--- a/gustaf/spline/create.py
+++ b/gustaf/spline/create.py
@@ -158,8 +158,8 @@ def revolve(spline, axis=None, center=None, angle=None, n_knot_spans=None):
     # Angle must be (0, pi) non including
     # Rotation is always performed in half steps
     PI = np.pi
-    round_tolerance = 1e-13
-    minimum_n_knot_spans = int(np.ceil(np.abs((angle + round_tolerance) / PI)))
+    minimum_n_knot_spans = int(
+        np.ceil(np.abs((angle + settings.TOLERANCE) / PI)))
     if (n_knot_spans) is None or (n_knot_spans < minimum_n_knot_spans):
         n_knot_spans = minimum_n_knot_spans
 

--- a/gustaf/spline/create.py
+++ b/gustaf/spline/create.py
@@ -195,9 +195,9 @@ def revolve(spline,
 
     # Determine rotation matrix
     rotation_matrix = utils.arr.rotation_matrix_around_axis(
-                          axis=axis,
-                          rotation=rot_a,
-                          degree=False
+        axis=axis,
+        rotation=rot_a,
+        degree=False
                       ).T
 
     # Start Extrusion

--- a/gustaf/utils/arr.py
+++ b/gustaf/utils/arr.py
@@ -92,7 +92,7 @@ def unique_rows(
         return_inverse=return_inverse,
         return_counts=return_counts,
     )
-    unique_stuff = list(unique_stuff) # list, to allow item assignment
+    unique_stuff = list(unique_stuff)  # list, to allow item assignment
 
     # switch view to original
     unique_stuff[0] = in_arr[unique_stuff[1]]
@@ -259,7 +259,9 @@ def rotate(arr, rotation, rotation_axis=None, degree=True):
     -----------
     arr: (n, (2 or 3)) list-like
     rotation: list or float
-    rotation_axis: (n, (2 or 3)) list-like
+      angle of rotation (around each axis)
+    rotation_axis: (n, (2 or 3)) list-like 
+      center of rotation
 
     Returns
     --------
@@ -284,3 +286,69 @@ def rotate(arr, rotation, rotation_axis=None, degree=True):
         rarr += rotation_axis
 
         return rarr
+
+
+def rotation_matrix_around_axis(
+        axis=None,
+        rotation=None,
+        degree=True):
+    """
+    Compute rotation matrix given the axis of rotation.
+    Works for both 2D and 3D
+    Uses Rodrigues' formula.
+
+    If axis is not specified, 2D rotation matrix is assumed.
+
+    Parameters
+    -----------
+    axis: list or np.ndarray
+      Axis of rotation in 3D
+    rotation: float
+      angle of rotation in either radiant or degrees
+    degree: bool
+      (Optional) rotation given in degrees.
+      Default is `True`. If `False`, in radian.
+
+    Returns
+    --------
+    rotation_matrix: np.ndarray (3,3) of np.ndarray (2,2)
+    """
+    # Assure angle is specified
+    if rotation is None:
+        raise ValueError("No rotation angle specified.")
+    else:
+        if degree:
+            rotation = np.radians(rotation)
+
+    # Check Problem dimensions
+    if axis is None:
+        problem_dimension = 2
+    else:
+        axis = np.asarray(axis).ravel()
+        if axis.shape[0] != 3:
+            raise ValueError("Axis dimension must be 3D")
+        problem_dimension = 3
+
+    # Assemble rotation matrix
+    if problem_dimension == 2:
+        rotation_matrix = np.array([
+            [np.cos(rotation), -np.sin(rotation)],
+            [np.sin(rotation), np.cos(rotation)]
+        ])
+    else:
+        # See Rodrigues' formula
+        rotation_matrix = np.array(
+            [[0, -axis[2], axis[1]],
+             [axis[2], 0, -axis[0]],
+             [axis[1], axis[0], 0]]
+        )
+        rotation_matrix = (
+            np.eye(3)
+            + np.sin(rotation) * rotation_matrix
+            + (
+                (1 - np.cos(rotation))
+                * np.matmul(rotation_matrix, rotation_matrix)
+            )
+        )
+
+    return rotation_matrix

--- a/gustaf/utils/arr.py
+++ b/gustaf/utils/arr.py
@@ -260,7 +260,7 @@ def rotate(arr, rotation, rotation_axis=None, degree=True):
     arr: (n, (2 or 3)) list-like
     rotation: list or float
       angle of rotation (around each axis)
-    rotation_axis: (n, (2 or 3)) list-like 
+    rotation_axis: (n, (2 or 3)) or (2 or 3) list-like 
       center of rotation
 
     Returns

--- a/tests/common.py
+++ b/tests/common.py
@@ -10,7 +10,7 @@ import numpy as np
 
 import gustaf as gus
 
-#gus.utils.log.configure(debug=True)
+# gus.utils.log.configure(debug=True)
 
 # Mesh Stuff
 V = np.array(
@@ -128,6 +128,44 @@ B1P2D_MUSTER = gus.BSpline(
     control_points=None,
 )
 
+CTPS_2D = np.array(
+    [
+        [0, 0],
+        [1, 0],
+        [2, 0],
+        [3, 0],
+        [4, 0],
+        [0, 1],
+        [1, 2],
+        [2, 1],
+        [3, 2],
+        [4, 1]
+    ],
+    dtype=np.float64,
+)
+
+KV_2D = [[0, 0, 0, .3, .7, 1, 1, 1], [0, 0, 1, 1]]
+
+DEGREES_2D_NU = [2, 1]
+DEGREES_2D_U = [4, 1]
+
+WEIGHTS_2D = np.array(
+    [
+        [1.0],
+        [0.8],
+        [1.0],
+        [0.8],
+        [1.0],
+        [1.0],
+        [0.8],
+        [1.0],
+        [0.8],
+        [1.0]
+    ],
+    dtype=np.float64,
+)
+
+
 # alias
 logconfig = gus.utils.log.configure
 
@@ -149,6 +187,11 @@ COMMON = namedtuple(
         "tet",
         "quad",
         "hexa",
+        "ctps2d",
+        "kv2d",
+        "degrees2dnu",
+        "degrees2du",
+        "weights2s"
     ]
 )
 
@@ -168,4 +211,9 @@ C = COMMON(
     tet=TET_MUSTER,
     quad=QUAD_MUSTER,
     hexa=HEXA_MUSTER,
+    ctps2d=CTPS_2D,
+    kv2d=KV_2D,
+    degrees2dnu=DEGREES_2D_NU,
+    degrees2du=DEGREES_2D_U,
+    weights2s=WEIGHTS_2D
 )

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -6,7 +6,7 @@ except:
     import common as c
 
 
-class ProximityTest(c.unittest.TestCase):
+class CreatorTest(c.unittest.TestCase):
 
     # Test Extrusion routines
     def test_create_extrude(self):

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -142,6 +142,9 @@ class ProximityTest(c.unittest.TestCase):
         # Expect Failure - axis wrong format
         with self.assertRaises(ValueError):
             bspline.create.revolve(axis=[1])
+        # Expect Failure - axis too small
+        with self.assertRaises(ValueError):
+            bspline.create.revolve(axis=[0, 0, 1e-18])
 
         # Revolve always around z-axis
         # init rotation matrix
@@ -197,8 +200,7 @@ class ProximityTest(c.unittest.TestCase):
                     spline_g.control_points - r_center,
                     R2.T
                 ) + r_center
-            ),
-                f"{spline_g.whatami} failed revolution around center")
+            ), f"{spline_g.whatami} failed revolution around center")
 
 
 if __name__ == "__main__":

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -166,7 +166,8 @@ class ProximityTest(c.unittest.TestCase):
                     spline_g.create.revolve(
                         axis=[0, 0, 1],
                         center=[0, 0, 0],
-                        angle=r_angle
+                        angle=r_angle,
+                        degree=False
                     ).control_points[-10:, :],
                     np.matmul(
                         np.hstack((
@@ -182,7 +183,10 @@ class ProximityTest(c.unittest.TestCase):
         # Test 2D Revolutions of lines
         for spline_g in (bezier_line, nurbs_line):
             self.assertTrue(np.allclose(
-                spline_g.create.revolve(angle=r_angle).control_points[-2:, :],
+                spline_g.create.revolve(
+                    angle=r_angle,
+                    degree=False
+                ).control_points[-2:, :],
                 np.matmul(
                     spline_g.control_points,
                     R2.T
@@ -194,7 +198,8 @@ class ProximityTest(c.unittest.TestCase):
             self.assertTrue(np.allclose(
                 spline_g.create.revolve(
                     angle=r_angle,
-                    center=r_center
+                    center=r_center,
+                    degree=False
                 ).control_points[-2:, :],
                 np.matmul(
                     spline_g.control_points - r_center,

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -173,7 +173,8 @@ class ProximityTest(c.unittest.TestCase):
                         R.T
                     )
                 ),
-                f"{spline_g.whatami} failed revolution")
+                f"{spline_g.whatami} failed revolution"
+            )
 
         # Test 2D Revolutions of lines
         for spline_g in (bezier_line, nurbs_line):

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,0 +1,204 @@
+import gustaf as gus
+import numpy as np
+try:
+    from . import common as c
+except:
+    import common as c
+
+
+class ProximityTest(c.unittest.TestCase):
+
+    # Test Extrusion routines
+    def test_create_extrude(self):
+        """
+        Test extrusion for different input types and arguments
+        """
+        # make a couple of 2D splines
+        bspline = gus.BSpline(
+            control_points=c.CTPS_2D,
+            degrees=c.DEGREES_2D_NU,
+            knot_vectors=c.KV_2D
+        )
+        nurbs = gus.NURBS(
+            control_points=c.CTPS_2D,
+            degrees=c.DEGREES_2D_NU,
+            knot_vectors=c.KV_2D,
+            weights=c.WEIGHTS_2D
+        )
+        bezier = gus.Bezier(
+            control_points=c.CTPS_2D,
+            degrees=c.DEGREES_2D_U,
+        )
+        rationalbezier = gus.RationalBezier(
+            control_points=c.CTPS_2D,
+            degrees=c.DEGREES_2D_U,
+            weights=c.WEIGHTS_2D
+        )
+
+        # Expect Failure - not a spline
+        with self.assertRaises(NotImplementedError):
+            gus.spline.create.extrude([4])
+        # Expect Failure - no axis given
+        with self.assertRaises(ValueError):
+            bspline.create.extrude()
+        # Expect Failure - axis wrong format
+        with self.assertRaises(ValueError):
+            bspline.create.extrude(extrusion_vector=[1])
+
+        # Create a random axis
+        axis = np.random.rand(3)
+        x, y, z = np.random.rand(3).tolist()
+
+        # Test results
+        for spline_g in (bspline, nurbs, rationalbezier, bezier):
+            self.assertTrue(
+                np.allclose(
+                    bspline.create.extrude(extrusion_vector=axis).evaluate(
+                        [[x, y, z]]
+                    ),
+                    np.hstack((
+                        bspline.evaluate([[x, y]]),
+                        np.zeros((1, 1))
+                    )) + z * axis
+                )
+            )
+
+        # Create a random axis
+        axis = np.random.rand(3)
+        x, y, z = np.random.rand(3).tolist()
+
+        # Test results
+        for spline_g in (bspline, nurbs, rationalbezier, bezier):
+            self.assertTrue(
+                np.allclose(
+                    spline_g.create.extrude(extrusion_vector=axis).evaluate(
+                        [[x, y, z]]
+                    ),
+                    np.hstack((
+                        spline_g.evaluate([[x, y]]),
+                        np.zeros((1, 1))
+                    )) + z * axis
+                )
+            )
+
+    # Test Revolution Routine
+    def test_create_revolution(self):
+        """
+        Test revolution routines for different input types and arguments
+        """
+        # make a couple of 2D splines
+        bspline = gus.BSpline(
+            control_points=c.CTPS_2D,
+            degrees=c.DEGREES_2D_NU,
+            knot_vectors=c.KV_2D
+        )
+        nurbs = gus.NURBS(
+            control_points=c.CTPS_2D,
+            degrees=c.DEGREES_2D_NU,
+            knot_vectors=c.KV_2D,
+            weights=c.WEIGHTS_2D
+        )
+        bezier = gus.Bezier(
+            control_points=c.CTPS_2D,
+            degrees=c.DEGREES_2D_U,
+        )
+        rationalbezier = gus.RationalBezier(
+            control_points=c.CTPS_2D,
+            degrees=c.DEGREES_2D_U,
+            weights=c.WEIGHTS_2D
+        )
+
+        # Make some lines
+        bezier_line = gus.Bezier(
+            control_points=[
+                [1, 0],
+                [2, 1]
+            ],
+            degrees=[1]
+        )
+        nurbs_line = bezier_line.nurbs
+
+        # Make a cuboid
+        cuboid = gus.Bezier(
+            control_points=[
+                [0, 0, 0],
+                [1, 0, 0],
+                [0, 1, 0],
+                [1, 1, 0],
+                [0, 0, 1],
+                [1, 0, 1],
+                [0, 1, 1],
+                [1, 1, 1]
+            ],
+            degrees=[1, 1, 1]
+        )
+
+        # Expect Failure - not a spline
+        with self.assertRaises(NotImplementedError):
+            gus.spline.create.revolve([4])
+        # Expect Failure - No rotation axis
+        with self.assertRaises(ValueError):
+            cuboid.create.revolve()
+        # Expect Failure - axis wrong format
+        with self.assertRaises(ValueError):
+            bspline.create.revolve(axis=[1])
+
+        # Revolve always around z-axis
+        # init rotation matrix
+        r_angle = np.random.rand()
+        r_center = -np.random.rand(2)
+        r_center = np.array([1, 0])
+        cc, ss = np.cos(r_angle), np.sin(r_angle)
+        R = np.array([
+            [cc, -ss, 0],
+            [ss, cc, 0],
+            [0, 0, 1]
+        ])
+        R2 = np.array([[cc, -ss], [ss, cc]])
+
+        # Test 3D revolutions for bodies
+        for spline_g in (bspline, nurbs, rationalbezier, bezier):
+            self.assertTrue(
+                np.allclose(
+                    spline_g.create.revolve(
+                        axis=[0, 0, 1],
+                        center=[0, 0, 0],
+                        angle=r_angle
+                    ).control_points[-10:, :],
+                    np.matmul(
+                        np.hstack((
+                            spline_g.control_points,
+                            np.zeros((spline_g.control_points.shape[0], 1))
+                        )),
+                        R.T
+                    )
+                ),
+                f"{spline_g.whatami} failed revolution")
+
+        # Test 2D Revolutions of lines
+        for spline_g in (bezier_line, nurbs_line):
+            self.assertTrue(np.allclose(
+                spline_g.create.revolve(angle=r_angle).control_points[-2:, :],
+                np.matmul(
+                    spline_g.control_points,
+                    R2.T
+                )
+            ))
+
+        # Test 2D Revolutions of lines around center
+        for spline_g in (bezier_line, nurbs_line):
+            self.assertTrue(np.allclose(
+                spline_g.create.revolve(
+                    angle=r_angle,
+                    center=r_center
+                ).control_points[-2:, :],
+                np.matmul(
+                    spline_g.control_points - r_center,
+                    R2.T
+                ) + r_center
+            ),
+                f"{spline_g.whatami} failed revolution around center")
+
+
+if __name__ == "__main__":
+    c.unittest.main()


### PR DESCRIPTION
# Creator Class
Added a `_Creator` class to be added as a member to all existing spline implementations. It provides 2 new functionalities, Spline extrusion and spline revolution.
## Extrusion
Example:
```
import gustaf as gus
spline = gus.BSpline(degrees=[1], control_points=[[0,0,0],[1,0,0]], knot_vectors=[[0,0,1,1]])
spline.create.extrude(axis=[0,0,1])
```
Some notes:
- Extraction is along `axis`
- Axis must be of same dimension as `control_points`
- extrusion is always linear, use degree elevation and knot insertion to get alternative splines

## Revolution
Example:
```
import gustaf as gus
spline = gus.BSpline(degrees=[1], control_points=[[0,0,0],[1,0,0]], knot_vectors=[[0,0,1,1]]).nurbs
spline.create.revolve(axis=[0,0,1], center=[0,0,0], angle=np.pi*0.25)
```
Some notes:
- Revolutions also work for non-rational splines, but produce a warning, as it only provides an approximation
- Beziers are only supported for up to 180° (non-including)

In summary, a way to create a cylinder would be:
```
import gustaf as gus
spline = gus.BSpline(degrees=[1], control_points=[[0,0,0],[1,0,0]], knot_vectors=[[0,0,1,1]]).nurbs
spline.create.revolve(axis=[0,0,1], center=[0,0,0], angle=np.pi*2, n_knot_spans=3).create.extrude(axis=[0,0,1])
``` 