### PR TITLE
Adding vertex and face groups to meshes

### DIFF
--- a/examples/diagonalize.py
+++ b/examples/diagonalize.py
@@ -1,0 +1,26 @@
+import gustaf as gus
+import numpy as np
+
+
+if __name__ == "__main__":
+    # create 4x5 element test mesh
+    v_res = [5, 6]
+    vertices = gus.create.vertices.raster(bounds=[[0, 0], [1, 1]], resolutions=v_res)
+    connec = gus.utils.connec.make_quad_faces(v_res)
+
+    quad = gus.Faces(vertices.vertices, connec)
+
+    tri = gus.create.faces.quad_to_tri(quad)
+
+    # show
+    quad.shrink().show()
+
+    gus.create.faces.quad_to_tri(quad, alternate=False).shrink().show()
+    gus.create.faces.quad_to_tri(quad, backslash=True, alternate=False).shrink().show()
+    gus.create.faces.quad_to_tri(quad).shrink().show()
+    gus.create.faces.quad_to_tri(quad, backslash=True).shrink().show()
+
+    tri = gus.create.faces.quad_to_tri(quad)
+    e = tri.shrink(ratio=0.7).toedges(False)
+    e.vis_dict["arrows"] = True
+    e.show()

--- a/examples/diagonalize.py
+++ b/examples/diagonalize.py
@@ -10,17 +10,17 @@ if __name__ == "__main__":
 
     quad = gus.Faces(vertices.vertices, connec)
 
-    tri = gus.create.faces.quad_to_tri(quad)
+    tri = gus.create.faces.simplexify(quad)
 
     # show
     quad.shrink().show()
 
-    gus.create.faces.quad_to_tri(quad, alternate=False).shrink().show()
-    gus.create.faces.quad_to_tri(quad, backslash=True, alternate=False).shrink().show()
-    gus.create.faces.quad_to_tri(quad).shrink().show()
-    gus.create.faces.quad_to_tri(quad, backslash=True).shrink().show()
+    gus.create.faces.simplexify(quad, alternate=False).shrink().show()
+    gus.create.faces.simplexify(quad, backslash=True, alternate=False).shrink().show()
+    gus.create.faces.simplexify(quad).shrink().show()
+    gus.create.faces.simplexify(quad, backslash=True).shrink().show()
 
-    tri = gus.create.faces.quad_to_tri(quad)
+    tri = gus.create.faces.simplexify(quad)
     e = tri.shrink(ratio=0.7).toedges(False)
     e.vis_dict["arrows"] = True
     e.show()

--- a/examples/diagonalize.py
+++ b/examples/diagonalize.py
@@ -4,16 +4,15 @@ import numpy as np
 
 if __name__ == "__main__":
     # create 4x5 element test mesh
-    v_res = [5, 6]
-    vertices = gus.create.vertices.raster(bounds=[[0, 0], [1, 1]], resolutions=v_res)
-    connec = gus.utils.connec.make_quad_faces(v_res)
-
-    quad = gus.Faces(vertices.vertices, connec)
+    quad = gus.create.faces.quad_block_mesh(
+            bounds = [[0, 0], [1, 1]],
+            resolutions = [5, 6]
+            )
 
     # we create vertex and face groups for testing purposes
-    quad.vertex_groups["odd_vertices"] = np.arange(vertices.vertices.shape[0],
+    quad.vertex_groups["odd_vertices"] = np.arange(quad.vertices.shape[0],
             step=2)
-    quad.face_groups["odd_faces"] = np.arange(connec.shape[0], step=2)
+    quad.face_groups["odd_faces"] = np.arange(quad.faces.shape[0], step=2)
 
     # show
     quad.shrink().show()

--- a/examples/diagonalize.py
+++ b/examples/diagonalize.py
@@ -13,6 +13,8 @@ if __name__ == "__main__":
     quad.vertex_groups["odd_vertices"] = np.arange(quad.vertices.shape[0],
             step=2)
     quad.face_groups["odd_faces"] = np.arange(quad.faces.shape[0], step=2)
+    quad.face_groups["even_faces"] = np.arange(start=1,
+            stop=quad.faces.shape[0], step=2)
 
     # show
     quad.shrink().show()
@@ -31,38 +33,33 @@ if __name__ == "__main__":
             gus.create.faces.simplexify(quad, backslash=True).shrink()]
             ]
 
-    vertex_group_plots = (
-                [[vertex_group, quad.extract_vertex_group(vertex_group)] for
-                    vertex_group in quad.vertex_groups] +
-                [[vertex_group, tri.extract_vertex_group(vertex_group)] for
-                    vertex_group in tri.vertex_groups]
-                )
+    quad_vertex_plot = gus.show.group_plot(quad.extract_all_vertex_groups())
+    tri_vertex_plot = gus.show.group_plot(tri.extract_all_vertex_groups())
 
-    edge_group_plots = (
-                [[edge_group, quad.extract_edge_group(edge_group).shrink()]
-                    for edge_group in quad.edge_groups] +
-                [[edge_group, tri.extract_edge_group(edge_group).shrink()]
-                    for edge_group in tri.edge_groups]
-                )
+    quad_edge_plot = gus.show.group_plot(quad.extract_all_edge_groups(),
+            shrink=0.95)
+    tri_edge_plot = gus.show.group_plot(tri.extract_all_edge_groups(),
+            shrink=0.95)
 
-    face_group_plots = (
-                [[face_group, quad.extract_face_group(face_group).shrink()]
-                    for face_group in quad.face_groups] +
-                [[face_group, tri.extract_face_group(face_group).shrink()]
-                    for face_group in tri.face_groups]
-                )
+    quad_face_plot = gus.show.group_plot(quad.extract_all_face_groups(),
+            shrink=0.95)
+    tri_face_plot = gus.show.group_plot(tri.extract_all_face_groups(),
+            shrink=0.95)
 
     try:
         import vedo
         gus.show.show_vedo(*option_plots)
-        gus.show.show_vedo(*vertex_group_plots)
-        gus.show.show_vedo(*edge_group_plots)
-        gus.show.show_vedo(*face_group_plots)
+        gus.show.show_vedo(quad_vertex_plot, tri_vertex_plot)
+        gus.show.show_vedo(quad_edge_plot, tri_edge_plot)
+        gus.show.show_vedo(quad_face_plot, tri_face_plot)
     except:
-        for item in (option_plots + vertex_group_plots +
-                edge_group_plots + face_group_plots):
+        for item in option_plots:
             print(f"Showing {item[0]}.")
             item[1].show()
+        for item in (quad_vertex_plot + tri_vertex_plot
+                + quad_edge_plot + tri_edge_plot
+                + quad_face_plot + tri_face_plot):
+            item.show()
 
     # show edges
     e = tri.shrink(ratio=0.7).toedges(False)

--- a/examples/diagonalize.py
+++ b/examples/diagonalize.py
@@ -10,17 +10,59 @@ if __name__ == "__main__":
 
     quad = gus.Faces(vertices.vertices, connec)
 
-    tri = gus.create.faces.simplexify(quad)
+    # we create vertex and face groups for testing purposes
+    quad.vertex_groups["odd_vertices"] = np.arange(vertices.vertices.shape[0],
+            step=2)
+    quad.face_groups["odd_faces"] = np.arange(connec.shape[0], step=2)
 
     # show
     quad.shrink().show()
 
-    gus.create.faces.simplexify(quad, alternate=False).shrink().show()
-    gus.create.faces.simplexify(quad, backslash=True, alternate=False).shrink().show()
-    gus.create.faces.simplexify(quad).shrink().show()
-    gus.create.faces.simplexify(quad, backslash=True).shrink().show()
-
     tri = gus.create.faces.simplexify(quad)
+
+    show_options = [
+            ["no backslash, no alternate",
+            gus.create.faces.simplexify(quad, alternate=False).shrink()],
+            ["backslash, no alternate",
+            gus.create.faces.simplexify(quad, backslash=True,
+                alternate=False).shrink()],
+            ["no backslash, alternate",
+            tri.shrink()],
+            ["backslash, alternate",
+            gus.create.faces.simplexify(quad, backslash=True).shrink()]
+            ]
+
+    try:
+        import vedo # if nothing's raised, following should be usable
+
+        gus.show.show_vedo(*show_options)
+
+        gus.show.show_vedo(*(
+                [[vertex_group, quad.extract_vertex_group(vertex_group)] for
+                    vertex_group in quad.vertex_groups] +
+                [[vertex_group, tri.extract_vertex_group(vertex_group)] for
+                    vertex_group in tri.vertex_groups] +
+                [[face_group, quad.extract_face_group(face_group).shrink()] for
+                    face_group in quad.face_groups] +
+                [[face_group, tri.extract_face_group(face_group).shrink()] for
+                    face_group in tri.face_groups]
+                ))
+    except:
+        for show_option in show_options:
+            print(f"Showing: {show_option[0]}")
+            show_option[1].show()
+
+        # show groups
+        for vertex_group in tri.vertex_groups:
+            print(f"Showing vertex group {vertex_group}.")
+            quad.extract_vertex_group(vertex_group).show()
+            tri.extract_vertex_group(vertex_group).show()
+        for face_group in tri.face_groups:
+            print(f"Showing face group {face_group}.")
+            quad.extract_face_group(face_group).shrink().show()
+            tri.extract_face_group(face_group).shrink().show()
+
+    # show edges
     e = tri.shrink(ratio=0.7).toedges(False)
     e.vis_dict["arrows"] = True
     e.show()

--- a/examples/diagonalize.py
+++ b/examples/diagonalize.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
 
     tri = gus.create.faces.simplexify(quad)
 
-    show_options = [
+    option_plots = [
             ["no backslash, no alternate",
             gus.create.faces.simplexify(quad, alternate=False).shrink()],
             ["backslash, no alternate",
@@ -31,37 +31,41 @@ if __name__ == "__main__":
             gus.create.faces.simplexify(quad, backslash=True).shrink()]
             ]
 
-    try:
-        import vedo # if nothing's raised, following should be usable
-
-        gus.show.show_vedo(*show_options)
-
-        gus.show.show_vedo(*(
+    vertex_group_plots = (
                 [[vertex_group, quad.extract_vertex_group(vertex_group)] for
                     vertex_group in quad.vertex_groups] +
                 [[vertex_group, tri.extract_vertex_group(vertex_group)] for
-                    vertex_group in tri.vertex_groups] +
-                [[face_group, quad.extract_face_group(face_group).shrink()] for
-                    face_group in quad.face_groups] +
-                [[face_group, tri.extract_face_group(face_group).shrink()] for
-                    face_group in tri.face_groups]
-                ))
-    except:
-        for show_option in show_options:
-            print(f"Showing: {show_option[0]}")
-            show_option[1].show()
+                    vertex_group in tri.vertex_groups]
+                )
 
-        # show groups
-        for vertex_group in tri.vertex_groups:
-            print(f"Showing vertex group {vertex_group}.")
-            quad.extract_vertex_group(vertex_group).show()
-            tri.extract_vertex_group(vertex_group).show()
-        for face_group in tri.face_groups:
-            print(f"Showing face group {face_group}.")
-            quad.extract_face_group(face_group).shrink().show()
-            tri.extract_face_group(face_group).shrink().show()
+    edge_group_plots = (
+                [[edge_group, quad.extract_edge_group(edge_group).shrink()]
+                    for edge_group in quad.edge_groups] +
+                [[edge_group, tri.extract_edge_group(edge_group).shrink()]
+                    for edge_group in tri.edge_groups]
+                )
+
+    face_group_plots = (
+                [[face_group, quad.extract_face_group(face_group).shrink()]
+                    for face_group in quad.face_groups] +
+                [[face_group, tri.extract_face_group(face_group).shrink()]
+                    for face_group in tri.face_groups]
+                )
+
+    try:
+        import vedo
+        gus.show.show_vedo(*option_plots)
+        gus.show.show_vedo(*vertex_group_plots)
+        gus.show.show_vedo(*edge_group_plots)
+        gus.show.show_vedo(*face_group_plots)
+    except:
+        for item in (option_plots + vertex_group_plots +
+                edge_group_plots + face_group_plots):
+            print(f"Showing {item[0]}.")
+            item[1].show()
 
     # show edges
     e = tri.shrink(ratio=0.7).toedges(False)
     e.vis_dict["arrows"] = True
     e.show()
+

--- a/examples/extrusion.py
+++ b/examples/extrusion.py
@@ -1,0 +1,23 @@
+import gustaf as gus
+import numpy as np
+
+if __name__ == "__main__":
+    # create 4x5 element test mesh
+    v_res = [5, 6]
+    vertices = gus.create.vertices.raster(bounds=[[0, 0], [1, 1]], resolutions=v_res)
+    connec = gus.utils.connec.make_quad_faces(v_res)
+    quad = gus.Faces(vertices.vertices, connec)
+    tri = gus.create.faces.quad_to_tri(quad)
+
+    # show
+    tri.shrink().show()
+
+    # 1 layer
+    tet1 = gus.create.volumes.extrude_tri_to_tet(tri, thickness = .2,
+            layers = 1, randomize = True)
+    tet1.show()
+
+    # 3 layers
+    tet3 = gus.create.volumes.extrude_tri_to_tet(tri, thickness = .2,
+            layers = 3, randomize = True)
+    tet3.shrink().show()

--- a/examples/extrusion.py
+++ b/examples/extrusion.py
@@ -3,15 +3,15 @@ import numpy as np
 
 if __name__ == "__main__":
     # create 4x5 element test mesh
-    v_res = [5, 6]
-    vertices = gus.create.vertices.raster(bounds=[[0, 0], [1, 1]], resolutions=v_res)
-    connec = gus.utils.connec.make_quad_faces(v_res)
-    quad = gus.Faces(vertices.vertices, connec)
+    quad = gus.create.faces.quad_block_mesh(
+            bounds = [[0, 0], [1, 1]],
+            resolutions = [5, 6]
+            )
 
     # we create vertex and face groups for testing purposes
-    quad.vertex_groups["odd_vertices"] = np.arange(vertices.vertices.shape[0],
-            step=2)
-    #quad.face_groups["odd_faces"] = quad.get_surfaces()[::2]
+    #quad.vertex_groups["odd_vertices"] = np.arange(vertices.vertices.shape[0],
+    #        step=2)
+    quad.face_groups["odd_faces"] = np.arange(quad.faces.shape[0], step=2)
 
     extrusion_plots = []
 
@@ -28,22 +28,40 @@ if __name__ == "__main__":
             layers = 3, randomize = True)
     extrusion_plots += [["3 layers", tet3.shrink()]]
 
-    group_plots = []
+    vertex_group_plots = []
     for vertex_group in quad.vertex_groups:
-        group_plots += [
-                [vertex_group, quad.extract_vertex_group(vertex_group)],
-                [vertex_group, tet3.extract_vertex_group(vertex_group)]
+        vertex_group_plots += [
+                [f"quad.{vertex_group}",
+                    quad.extract_vertex_group(vertex_group)],
+                [f"tet3.{vertex_group}",
+                    tet3.extract_vertex_group(vertex_group)]
                 ]
+
+    face_group_plots = []
+    for edge_group in quad.edge_groups:
+        face_group_plots += [[f"quad.{edge_group}",
+            quad.extract_edge_group(edge_group).shrink()]]
     for face_group in tet3.face_groups:
-        group_plots += [[face_group,
+        face_group_plots += [[f"tet3.{face_group}",
             tet3.extract_face_group(face_group).shrink()]]
+
+    volume_group_plots = []
+    for face_group in quad.face_groups:
+        volume_group_plots += [[f"quad.{face_group}",
+            quad.extract_face_group(face_group).shrink()]]
+    for volume_group in tet3.volume_groups:
+        volume_group_plots += [[f"tet3.{volume_group}",
+            tet3.extract_volume_group(volume_group).shrink()]]
 
     try:
         import vedo
         gus.show.show_vedo(*extrusion_plots)
-        gus.show.show_vedo(*group_plots)
+        gus.show.show_vedo(*vertex_group_plots)
+        gus.show.show_vedo(*face_group_plots)
+        gus.show.show_vedo(*volume_group_plots)
     except:
-        for item in extrusion_plots + group_plots:
+        for item in (extrusion_plots + vertex_group_plots + face_group_plots
+                + volume_group_plots):
             print(f"Showing {item[0]}.")
             item[1].show()
 

--- a/examples/extrusion.py
+++ b/examples/extrusion.py
@@ -9,9 +9,9 @@ if __name__ == "__main__":
             )
 
     # we create vertex and face groups for testing purposes
-    #quad.vertex_groups["odd_vertices"] = np.arange(vertices.vertices.shape[0],
-    #        step=2)
     quad.face_groups["odd_faces"] = np.arange(quad.faces.shape[0], step=2)
+    quad.face_groups["even_faces"] = np.arange(start=1,
+            stop=quad.faces.shape[0], step=2)
 
     extrusion_plots = []
 
@@ -28,40 +28,35 @@ if __name__ == "__main__":
             layers = 3, randomize = True)
     extrusion_plots += [["3 layers", tet3.shrink()]]
 
-    vertex_group_plots = []
-    for vertex_group in quad.vertex_groups:
-        vertex_group_plots += [
-                [f"quad.{vertex_group}",
-                    quad.extract_vertex_group(vertex_group)],
-                [f"tet3.{vertex_group}",
-                    tet3.extract_vertex_group(vertex_group)]
-                ]
+    quad_vertex_plot = gus.show.group_plot(quad.extract_all_vertex_groups())
+    tet_vertex_plot = gus.show.group_plot(tet3.extract_all_vertex_groups())
 
-    face_group_plots = []
-    for edge_group in quad.edge_groups:
-        face_group_plots += [[f"quad.{edge_group}",
-            quad.extract_edge_group(edge_group).shrink()]]
-    for face_group in tet3.face_groups:
-        face_group_plots += [[f"tet3.{face_group}",
-            tet3.extract_face_group(face_group).shrink()]]
+    quad_boundary_plot = gus.show.group_plot(
+            quad.extract_all_subelement_groups(),
+            shrink=0.98)
+    tet_boundary_plot = gus.show.group_plot(
+            tet3.extract_all_subelement_groups(),
+            shrink=0.98)
 
-    volume_group_plots = []
-    for face_group in quad.face_groups:
-        volume_group_plots += [[f"quad.{face_group}",
-            quad.extract_face_group(face_group).shrink()]]
-    for volume_group in tet3.volume_groups:
-        volume_group_plots += [[f"tet3.{volume_group}",
-            tet3.extract_volume_group(volume_group).shrink()]]
+    quad_element_plot = gus.show.group_plot(
+            quad.extract_all_element_groups(),
+            shrink=0.8)
+    tet_element_plot = gus.show.group_plot(
+            tet3.extract_all_element_groups(),
+            shrink=0.8)
 
     try:
         import vedo
         gus.show.show_vedo(*extrusion_plots)
-        gus.show.show_vedo(*vertex_group_plots)
-        gus.show.show_vedo(*face_group_plots)
-        gus.show.show_vedo(*volume_group_plots)
+        gus.show.show_vedo(quad_vertex_plot, tet_vertex_plot)
+        gus.show.show_vedo(quad_boundary_plot, tet_boundary_plot)
+        gus.show.show_vedo(quad_element_plot, tet_element_plot)
     except:
-        for item in (extrusion_plots + vertex_group_plots + face_group_plots
-                + volume_group_plots):
+        for item in extrusion_plots:
             print(f"Showing {item[0]}.")
             item[1].show()
+        for item in (quad_vertex_plot + tet_vertex_plot
+                + quad_boundary_plot + tet_boundary_plot
+                + quad_element_plot + tet_element_plot):
+            item.show()
 

--- a/examples/extrusion.py
+++ b/examples/extrusion.py
@@ -13,37 +13,37 @@ if __name__ == "__main__":
             step=2)
     #quad.face_groups["odd_faces"] = quad.get_surfaces()[::2]
 
-    show_list_1 = []
+    extrusion_plots = []
 
     # show
-    show_list_1 += [["quad", quad.shrink()]]
+    extrusion_plots += [["quad", quad.shrink()]]
 
     # 1 layer
     tet1 = gus.create.volumes.extrude_to_tet(quad, thickness = .2,
             layers = 1, randomize = True)
-    show_list_1 += [["1 layer", tet1]]
+    extrusion_plots += [["1 layer", tet1]]
 
     # 3 layers
     tet3 = gus.create.volumes.extrude_to_tet(quad, thickness = .2,
             layers = 3, randomize = True)
-    show_list_1 += [["3 layers", tet3.shrink()]]
+    extrusion_plots += [["3 layers", tet3.shrink()]]
 
-    show_list_2 = []
+    group_plots = []
     for vertex_group in quad.vertex_groups:
-        show_list_2 += [
+        group_plots += [
                 [vertex_group, quad.extract_vertex_group(vertex_group)],
                 [vertex_group, tet3.extract_vertex_group(vertex_group)]
                 ]
     for face_group in tet3.face_groups:
-        show_list_2 += [[face_group,
+        group_plots += [[face_group,
             tet3.extract_face_group(face_group).shrink()]]
 
     try:
         import vedo
-        gus.show.show_vedo(*show_list_1)
-        gus.show.show_vedo(*show_list_2)
+        gus.show.show_vedo(*extrusion_plots)
+        gus.show.show_vedo(*group_plots)
     except:
-        for item in show_list_1 + show_list_2:
+        for item in extrusion_plots + group_plots:
             print(f"Showing {item[0]}.")
             item[1].show()
 

--- a/examples/extrusion.py
+++ b/examples/extrusion.py
@@ -8,15 +8,42 @@ if __name__ == "__main__":
     connec = gus.utils.connec.make_quad_faces(v_res)
     quad = gus.Faces(vertices.vertices, connec)
 
+    # we create vertex and face groups for testing purposes
+    quad.vertex_groups["odd_vertices"] = np.arange(vertices.vertices.shape[0],
+            step=2)
+    #quad.face_groups["odd_faces"] = quad.get_surfaces()[::2]
+
+    show_list_1 = []
+
     # show
-    quad.shrink().show()
+    show_list_1 += [["quad", quad.shrink()]]
 
     # 1 layer
     tet1 = gus.create.volumes.extrude_to_tet(quad, thickness = .2,
             layers = 1, randomize = True)
-    tet1.show()
+    show_list_1 += [["1 layer", tet1]]
 
     # 3 layers
     tet3 = gus.create.volumes.extrude_to_tet(quad, thickness = .2,
             layers = 3, randomize = True)
-    tet3.shrink().show()
+    show_list_1 += [["3 layers", tet3.shrink()]]
+
+    show_list_2 = []
+    for vertex_group in quad.vertex_groups:
+        show_list_2 += [
+                [vertex_group, quad.extract_vertex_group(vertex_group)],
+                [vertex_group, tet3.extract_vertex_group(vertex_group)]
+                ]
+    for face_group in tet3.face_groups:
+        show_list_2 += [[face_group,
+            tet3.extract_face_group(face_group).shrink()]]
+
+    try:
+        import vedo
+        gus.show.show_vedo(*show_list_1)
+        gus.show.show_vedo(*show_list_2)
+    except:
+        for item in show_list_1 + show_list_2:
+            print(f"Showing {item[0]}.")
+            item[1].show()
+

--- a/examples/extrusion.py
+++ b/examples/extrusion.py
@@ -7,17 +7,16 @@ if __name__ == "__main__":
     vertices = gus.create.vertices.raster(bounds=[[0, 0], [1, 1]], resolutions=v_res)
     connec = gus.utils.connec.make_quad_faces(v_res)
     quad = gus.Faces(vertices.vertices, connec)
-    tri = gus.create.faces.quad_to_tri(quad)
 
     # show
-    tri.shrink().show()
+    quad.shrink().show()
 
     # 1 layer
-    tet1 = gus.create.volumes.extrude_tri_to_tet(tri, thickness = .2,
+    tet1 = gus.create.volumes.extrude_to_tet(quad, thickness = .2,
             layers = 1, randomize = True)
     tet1.show()
 
     # 3 layers
-    tet3 = gus.create.volumes.extrude_tri_to_tet(tri, thickness = .2,
+    tet3 = gus.create.volumes.extrude_to_tet(quad, thickness = .2,
             layers = 3, randomize = True)
     tet3.shrink().show()

--- a/examples/groups.py
+++ b/examples/groups.py
@@ -2,28 +2,30 @@ import gustaf as gus
 import numpy as np
 
 if __name__ == "__main__":
-    v = gus.create.volumes.hexa_block_mesh(
-        bounds=[[0, 0, 0], [1, 1, 1]],
-        resolutions=[4, 5, 6]
-        )
+    for creation_routine in (gus.create.volumes.hexa_block_mesh,
+            gus.create.volumes.tet_block_mesh):
+        v = creation_routine(
+            bounds=[[0, 0, 0], [1, 1, 1]],
+            resolutions=[4, 5, 6]
+            )
 
-    # show boundaries
-    boundary_plot = gus.show.group_plot(v.extract_all_subelement_groups(),
-            shrink=0.98)
+        # show boundaries
+        boundary_plot = gus.show.group_plot(v.extract_all_subelement_groups(),
+                shrink=0.98)
 
-    # create volume groups
-    v.volume_groups["odd_elements"] = np.arange(v.volumes.shape[0], step=2)
-    v.volume_groups["even_elements"] = np.arange(start=1,
-            stop=v.volumes.shape[0], step=2)
+        # create volume groups
+        v.volume_groups["odd_elements"] = np.arange(v.volumes.shape[0], step=2)
+        v.volume_groups["even_elements"] = np.arange(start=1,
+                stop=v.volumes.shape[0], step=2)
 
-    # show volume groups
-    group_plot = gus.show.group_plot(v.extract_all_element_groups(),
-            shrink=0.8)
+        # show volume groups
+        group_plot = gus.show.group_plot(v.extract_all_element_groups(),
+                shrink=0.8)
 
-    try:
-        import vedo
-        gus.show.show_vedo(boundary_plot, group_plot)
-    except:
-        for item in boundary_plot + group_plot:
-            item.show()
+        try:
+            import vedo
+            gus.show.show_vedo(boundary_plot, group_plot)
+        except:
+            for item in boundary_plot + group_plot:
+                item.show()
 

--- a/examples/groups.py
+++ b/examples/groups.py
@@ -7,34 +7,23 @@ if __name__ == "__main__":
         resolutions=[4, 5, 6]
         )
 
-    plots = []
-
-    # show original mesh
-    plots.append(["v", v.shrink()])
-
-    # show face groups
-    #for face_group in v.face_groups:
-    #    plots.append([face_group, v.extract_face_group(face_group).shrink()])
-    for element_group in v.get_subelement_groups():
-        plots.append([element_group,
-            v.extract_subelement_group(element_group).shrink()])
+    # show boundaries
+    boundary_plot = gus.show.group_plot(v.extract_all_subelement_groups(),
+            shrink=0.98)
 
     # create volume groups
     v.volume_groups["odd_elements"] = np.arange(v.volumes.shape[0], step=2)
+    v.volume_groups["even_elements"] = np.arange(start=1,
+            stop=v.volumes.shape[0], step=2)
 
     # show volume groups
-    for element_group in v.get_element_groups():
-        plots.append([element_group,
-            v.extract_element_group(element_group).shrink()])
-    #for volume_group in v.volume_groups:
-    #    plots.append([volume_group,
-    #        v.extract_volume_group(volume_group).shrink()])
+    group_plot = gus.show.group_plot(v.extract_all_element_groups(),
+            shrink=0.8)
 
     try:
         import vedo
-        gus.show.show_vedo(*plots)
+        gus.show.show_vedo(boundary_plot, group_plot)
     except:
-        for item in plots:
-            print(f"Showing {item[0]}.")
-            item[1].show()
+        for item in boundary_plot + group_plot:
+            item.show()
 

--- a/examples/groups.py
+++ b/examples/groups.py
@@ -1,0 +1,34 @@
+import gustaf as gus
+import numpy as np
+
+if __name__ == "__main__":
+    # create 2x3x4 test hexa element
+    v_res = [2, 3, 4]
+    vertices = gus.create.vertices.raster(
+        bounds=[[0, 0, 0], [1, 1, 1]],
+        resolutions=v_res
+    )
+    connec = gus.utils.connec.make_hexa_volumes(v_res)
+    v = gus.Volumes(vertices.vertices, connec)
+
+    plots = []
+
+    # show original mesh
+    plots.append(["v", v.shrink()])
+
+    # create a face group
+    v.face_groups["odd_faces"] = v.get_surfaces()[::2]
+    plots.append(["odd_faces", v.extract_face_group("odd_faces").shrink()])
+
+    # create vertex group
+    v.face_groups.export_all_vertex_groups()
+    plots.append(["odd_faces", v.extract_vertex_group("odd_faces")])
+
+    try:
+        import vedo
+        gus.show.show_vedo(*plots)
+    except:
+        for item in plots:
+            print(f"Showing {item[0]}.")
+            item[1].show()
+

--- a/examples/groups.py
+++ b/examples/groups.py
@@ -13,16 +13,22 @@ if __name__ == "__main__":
     plots.append(["v", v.shrink()])
 
     # show face groups
-    for face_group in v.face_groups:
-        plots.append([face_group, v.extract_face_group(face_group).shrink()])
+    #for face_group in v.face_groups:
+    #    plots.append([face_group, v.extract_face_group(face_group).shrink()])
+    for element_group in v.get_subelement_groups():
+        plots.append([element_group,
+            v.extract_subelement_group(element_group).shrink()])
 
     # create volume groups
     v.volume_groups["odd_elements"] = np.arange(v.volumes.shape[0], step=2)
 
     # show volume groups
-    for volume_group in v.volume_groups:
-        plots.append([volume_group,
-            v.extract_volume_group(volume_group).shrink()])
+    for element_group in v.get_element_groups():
+        plots.append([element_group,
+            v.extract_element_group(element_group).shrink()])
+    #for volume_group in v.volume_groups:
+    #    plots.append([volume_group,
+    #        v.extract_volume_group(volume_group).shrink()])
 
     try:
         import vedo

--- a/examples/groups.py
+++ b/examples/groups.py
@@ -2,27 +2,27 @@ import gustaf as gus
 import numpy as np
 
 if __name__ == "__main__":
-    # create 2x3x4 test hexa element
-    v_res = [2, 3, 4]
-    vertices = gus.create.vertices.raster(
+    v = gus.create.volumes.hexa_block_mesh(
         bounds=[[0, 0, 0], [1, 1, 1]],
-        resolutions=v_res
-    )
-    connec = gus.utils.connec.make_hexa_volumes(v_res)
-    v = gus.Volumes(vertices.vertices, connec)
+        resolutions=[4, 5, 6]
+        )
 
     plots = []
 
     # show original mesh
     plots.append(["v", v.shrink()])
 
-    # create a face group
-    v.face_groups["odd_faces"] = v.get_surfaces()[::2]
-    plots.append(["odd_faces", v.extract_face_group("odd_faces").shrink()])
+    # show face groups
+    for face_group in v.face_groups:
+        plots.append([face_group, v.extract_face_group(face_group).shrink()])
 
-    # create vertex group
-    v.face_groups.export_all_vertex_groups()
-    plots.append(["odd_faces", v.extract_vertex_group("odd_faces")])
+    # create volume groups
+    v.volume_groups["odd_elements"] = np.arange(v.volumes.shape[0], step=2)
+
+    # show volume groups
+    for volume_group in v.volume_groups:
+        plots.append([volume_group,
+            v.extract_volume_group(volume_group).shrink()])
 
     try:
         import vedo

--- a/examples/shrink_elements.py
+++ b/examples/shrink_elements.py
@@ -3,13 +3,10 @@ import numpy as np
 
 if __name__ == "__main__":
     # create 2x3x4 test hexa element
-    v_res = [2, 3, 4]
-    vertices = gus.create.vertices.raster(
+    v = gus.create.volumes.hexa_block_mesh(
         bounds=[[0, 0, 0], [1, 1, 1]],
-        resolutions=v_res
-    )
-    connec = gus.utils.connec.make_hexa_volumes(v_res)
-    v = gus.Volumes(vertices.vertices, connec)
+        resolutions=[2, 3, 4]
+        )
 
     try:
         import vedo # if nothing's raised, following should be usable

--- a/gustaf/create/__init__.py
+++ b/gustaf/create/__init__.py
@@ -1,4 +1,4 @@
-from gustaf.create import vertices
+from gustaf.create import vertices, faces
 
 try:
     from gustaf.create import spline

--- a/gustaf/create/__init__.py
+++ b/gustaf/create/__init__.py
@@ -1,4 +1,4 @@
-from gustaf.create import vertices, faces
+from gustaf.create import vertices, faces, volumes
 
 try:
     from gustaf.create import spline

--- a/gustaf/create/faces.py
+++ b/gustaf/create/faces.py
@@ -6,9 +6,60 @@ Routines to create faces.
 import numpy as np
 
 from gustaf.faces import Faces
-from gustaf.utils import log
+from gustaf import utils, create
 from gustaf import settings
 
+def quad_block_mesh(
+        bounds = [[0, 0], [1, 1]],
+        resolutions = [2, 2],
+        create_vertex_groups = True,
+        create_edge_groups = True
+        ):
+    """
+    Create structured quadrangle block mesh.
+
+    Parameters
+    -----------
+    bounds: (2, 2) array
+        Minimum and maximum coordinates.
+    resolutions: (2) array
+        Vertex count in each dimension.
+    create_vertex_groups: bool
+    create_face_groups: bool
+
+    Returns
+    --------
+    face_mesh: Volumes
+    """
+    assert np.array(bounds).shape == (2, 2), \
+            "bounds array must have 2x2 entries."
+    assert len(resolutions) == 2, \
+            "resolutions array must have two entries."
+    assert np.greater(resolutions, 1).all(), \
+            "All resolutions must be at least 2."
+
+    vertex_mesh = create.vertices.raster(bounds, resolutions)
+
+    if not create_vertex_groups and not create_face_groups:
+        connectivity = utils.connec.make_quad_faces(
+                resolutions, create_vertex_groups=False)
+        face_mesh = Faces(vertex_mesh.vertices, connectivity)
+    else:
+        connectivity, vertex_groups = utils.connec.make_quad_faces(
+                resolutions, create_vertex_groups=True)
+        face_mesh = Faces(vertex_mesh.vertices, connectivity)
+
+        if create_vertex_groups:
+            for group_name, vertex_ids in vertex_groups.items():
+                face_mesh.vertex_groups[group_name] = vertex_ids
+        if create_edge_groups:
+            edge_connectivity = face_mesh.get_edges()
+            for group_name, vertex_ids in vertex_groups.items():
+                face_mesh.edge_groups[group_name] = (
+                utils.groups.vertex_to_element_group(edge_connectivity,
+                        vertex_ids))
+
+    return face_mesh
 
 def simplexify(quad, backslash=False, alternate=True):
     """
@@ -45,9 +96,9 @@ def simplexify(quad, backslash=False, alternate=True):
         )
 
     if alternate == True:
-        log.warning("Be aware that even though `alternate=True` was set, "
-                "the diagonals might not alternate direction as expected, "
-                "depending on mesh structure and element order.")
+        utils.log.warning("Be aware that even though `alternate=True` was "
+                "set, the diagonals might not alternate direction as "
+                "expected, depending on mesh structure and element order.")
 
     # split variants
     split_slash = [[0, 1, 2], [2, 3, 0]]

--- a/gustaf/create/faces.py
+++ b/gustaf/create/faces.py
@@ -59,21 +59,28 @@ def quad_to_tri(quad, backslash=False, alternate=True):
         split_fav = split_backslash if backslash else split_slash
         split_alt = split_slash if backslash else split_backslash
 
-        split_fav_intersections = list(set(split_fav[0]).intersection(split_fav[1]))
+        split_fav_intersections = np.intersect1d(split_fav[0], split_fav[1],
+                assume_unique=True)
 
-        intersection_vertices = set()
+        intersection_vertices = np.full(quad.vertices.shape[0], False)
         for quad_index, quad_face in enumerate(quad_faces):
-            element_intersection_vertices = intersection_vertices & set(quad_face)
-            if not element_intersection_vertices:
+            element_intersection_vertices =\
+                    quad_face[intersection_vertices[quad_face]]
+            if not len(element_intersection_vertices):
                 split = split_fav
             else:
-                split = split_fav if not\
-                set(quad_face[split_fav_intersections]).isdisjoint(element_intersection_vertices)\
+                split = split_fav if np.isin(
+                        element_intersection_vertices,
+                        quad_face[split_fav_intersections],
+                        assume_unique=True).any() \
                 else split_alt
 
             # would be more efficient here to work with a pre-calculated
             # intersection of split[0] and split[1]
-            intersection_vertices |= set(quad_face[split[0]]) & set(quad_face[split[1]])
+            new_intersection_vertices =\
+                    quad_face[np.intersect1d(split[0], split[1],
+                    assume_unique=True)]
+            intersection_vertices[new_intersection_vertices] = True
 
             tri_faces[quad_index] = quad_face[split[0]]
             tri_faces[quad_index + tf_half] = quad_face[split[1]]

--- a/gustaf/create/faces.py
+++ b/gustaf/create/faces.py
@@ -88,12 +88,21 @@ def simplexify(quad, backslash=False, alternate=True):
                     assume_unique=True)]
             intersection_vertices[new_intersection_vertices] = True
 
-            tri_faces[quad_index] = quad_face[split[0]]
-            tri_faces[quad_index + tf_half] = quad_face[split[1]]
+            tri_faces[2 * quad_index] = quad_face[split[0]]
+            tri_faces[2 * quad_index + 1] = quad_face[split[1]]
 
     tri = Faces(
         vertices=quad.vertices.copy(),
         faces=tri_faces,
     )
+
+    # since the vertices are identical, copy vertex groups
+    for group_name, group_vertex_ids in quad.vertex_groups.items():
+        tri.vertex_groups[group_name] = group_vertex_ids
+
+    # create matching face groups
+    tri_face_ids = np.arange(tri_faces.shape[0]).reshape(-1, 2)
+    for group_name, group_face_ids in quad.face_groups.items():
+        tri.face_groups[group_name] = tri_face_ids[group_face_ids].flatten()
 
     return tri

--- a/gustaf/create/faces.py
+++ b/gustaf/create/faces.py
@@ -1,0 +1,86 @@
+"""gustaf/create/faces.py
+
+Routines to create faces.
+"""
+
+import numpy as np
+
+from gustaf.faces import Faces
+
+
+def quad_to_tri(quad, backslash=False, alternate=True):
+    """
+    Given quad faces, diagonalize them to turn them into triangles.
+    If quad is CCW, triangle will also be CCW and vice versa.
+    Default diagonalization looks like this:
+
+    (3) *---* (2)
+        |  /|
+        | / |
+        |/  |
+    (0) *---* (1)
+    resembling 'slash'.
+    If you want to diagonalize the other way, set `backslash=True`.
+
+    The algorithm will try to alternate the diagonal directions of neighboring
+    elements, if `alternate=True`. This will only work well if the elements are
+    ordered in a suitable manner.
+
+    Parameters
+    ----------
+    quad: Faces
+    backslash: bool
+    alternate: bool
+
+    Returns
+    --------
+    tri: Faces
+    """
+    if quad.get_whatami() != "quad":
+        raise ValueError(
+            "Input to quad_to_tri needs to be a quad mesh, but it's "
+            + quad.get_whatami()
+        )
+
+    # split variants
+    split_slash = [[0, 1, 2], [2, 3, 0]]
+    split_backslash = [[0, 1, 3], [3, 1, 2]]
+
+    quad_faces = quad.faces
+    tf_half = int(quad_faces.shape[0])
+    tri_faces = np.ones((tf_half * 2, 3), dtype=np.int32) * -1
+
+    if not alternate:
+        split = split_backslash if backslash else split_slash
+
+        tri_faces[:tf_half] = quad_faces[:, split[0]]
+        tri_faces[tf_half:] = quad_faces[:, split[1]]
+    else:
+        split_fav = split_backslash if backslash else split_slash
+        split_alt = split_slash if backslash else split_backslash
+
+        split_fav_intersections = list(set(split_fav[0]).intersection(split_fav[1]))
+
+        intersection_vertices = set()
+        for quad_index, quad_face in enumerate(quad_faces):
+            element_intersection_vertices = intersection_vertices & set(quad_face)
+            if not element_intersection_vertices:
+                split = split_fav
+            else:
+                split = split_fav if not\
+                set(quad_face[split_fav_intersections]).isdisjoint(element_intersection_vertices)\
+                else split_alt
+
+            # would be more efficient here to work with a pre-calculated
+            # intersection of split[0] and split[1]
+            intersection_vertices |= set(quad_face[split[0]]) & set(quad_face[split[1]])
+
+            tri_faces[quad_index] = quad_face[split[0]]
+            tri_faces[quad_index + tf_half] = quad_face[split[1]]
+
+    tri = Faces(
+        vertices=quad.vertices.copy(),
+        faces=tri_faces,
+    )
+
+    return tri

--- a/gustaf/create/faces.py
+++ b/gustaf/create/faces.py
@@ -186,3 +186,52 @@ def simplexify(quad, backslash=False, alternate=True):
                 matches[:, 0]] * number_of_tri_edges + matches[:, 1]
 
     return tri
+
+def tri_block_mesh(
+        bounds = [[0, 0], [1, 1]],
+        resolutions = [2, 2],
+        create_vertex_groups = True,
+        create_edge_groups = True,
+        alternate_diagonals = True
+        ):
+    """
+    Create structured triangle block mesh.
+
+    This combines `quad_block_mesh` and `simplexify`.
+
+    Parameters
+    -----------
+    bounds: (2, 2) array
+        Minimum and maximum coordinates.
+    resolutions: (2) array
+        Vertex count in each dimension.
+    create_vertex_groups: bool
+    create_face_groups: bool
+    alternate_diagonals : bool
+        (Default: True) Alternate diagonals during simplexification.
+
+    Returns
+    --------
+    face_mesh: Volumes
+    """
+    assert np.array(bounds).shape == (2, 2), \
+            "bounds array must have 2x2 entries."
+    assert len(resolutions) == 2, \
+            "resolutions array must have two entries."
+    assert np.greater(resolutions, 1).all(), \
+            "All resolutions must be at least 2."
+
+    # create quad mesh as basis
+    quad_mesh = quad_block_mesh(
+            bounds=bounds,
+            resolutions=resolutions,
+            create_vertex_groups=create_vertex_groups,
+            create_edge_groups=create_edge_groups
+            )
+
+    # turn into triangles
+    tri_mesh = simplexify(quad_mesh,
+            alternate=alternate_diagonals)
+
+    return tri_mesh
+

--- a/gustaf/create/faces.py
+++ b/gustaf/create/faces.py
@@ -182,7 +182,7 @@ def simplexify(quad, backslash=False, alternate=True):
         matches = np.argwhere(np.equal(group_tri_edges, group_edges).all(
             axis=2).reshape(-1, number_of_tri_edges))
         # get tri edge IDs
-        tri.edge_groups[group_name] = group_tri_face_ids.flatten()[
-                matches[:,0]] * number_of_tri_edges + matches[:,1]
+        tri.edge_groups[group_name] = group_tri_face_ids[
+                matches[:, 0]] * number_of_tri_edges + matches[:, 1]
 
     return tri

--- a/gustaf/create/volumes.py
+++ b/gustaf/create/volumes.py
@@ -7,14 +7,17 @@ import numpy as np
 import random
 
 from gustaf.volumes import Volumes
+from gustaf.utils import log
+from gustaf import create
 
-
-def extrude_tri_to_tet(tri, thickness = 1., layers = 1, randomize = False):
+def extrude_to_tet(source, thickness = 1., layers = 1, randomize = False):
     """
-    Given triangular faces, create three-dimensional tetrahedral volumes.
+    Given triangular or quadrangular faces, create three-dimensional tetrahedral
+    volumes.
 
     The direct extrusion of a triangle is a 6-vertex wedge. This is divided into
-    three tetrahedra.
+    three tetrahedra. If quadrangles are provided, they will be converted to
+    triangles.
 
     The method is deterministic by default. It walks over the flat vertices in
     given order and lifts them up by create volumes on the surrounding faces.
@@ -24,7 +27,7 @@ def extrude_tri_to_tet(tri, thickness = 1., layers = 1, randomize = False):
 
     Parameters
     ----------
-    tri: Faces
+    source: Faces
     thickness: float
     layers: int
     randomize: bool
@@ -36,22 +39,27 @@ def extrude_tri_to_tet(tri, thickness = 1., layers = 1, randomize = False):
     if layers < 1:
         raise ValueError("The number of layers must be >1.")
 
-    if tri.get_whatami() != "tri":
+    if not source.get_whatami() in ["tri", "quad"]:
         raise ValueError(
-            "Input to extrude_tri_to_tet needs to be a tri mesh, but it's "
-            + tri.get_whatami()
+            "Input to extrude_to_tet needs to be a tri or quad mesh, but it's "
+            + source.get_whatami()
         )
 
+    if source.get_whatami() == "quad":
+        log.info("Quadrangle mesh provided to `extrude_to_tet`. Creating "
+                "triangles to continue.")
+        source = create.faces.simplexify(source)
+
     # nodes
-    number_of_2d_nodes = tri.vertices.shape[0]
+    number_of_2d_nodes = source.vertices.shape[0]
     number_of_3d_nodes = (layers + 1) * number_of_2d_nodes
     # node coordinates
     vertices_3d = np.zeros([number_of_3d_nodes, 3])
-    vertices_3d[:,:2] = np.tile(tri.vertices, [layers + 1, 1])
+    vertices_3d[:,:2] = np.tile(source.vertices, [layers + 1, 1])
     vertices_3d[:,2] = np.repeat(np.arange(layers + 1) *
             thickness, number_of_2d_nodes)
     # elements
-    number_of_2d_faces = tri.faces.shape[0]
+    number_of_2d_faces = source.faces.shape[0]
     number_of_3d_volumes = layers * 3 * number_of_2d_faces
     volumes_3d = np.zeros([number_of_3d_volumes, 4])
     # this is an array that maps from a 2d vertex index to the current upper
@@ -62,7 +70,7 @@ def extrude_tri_to_tet(tri, thickness = 1., layers = 1, randomize = False):
     node_elements = dict()
     for vertex_id in range(number_of_2d_nodes):
         node_elements[vertex_id] = list()
-    for face_index, face in enumerate(tri.faces):
+    for face_index, face in enumerate(source.faces):
         for vertex_id in face:
             node_elements[vertex_id].append(face_index)
 
@@ -81,7 +89,7 @@ def extrude_tri_to_tet(tri, thickness = 1., layers = 1, randomize = False):
             for face_id in face_ids:
                 # create element
                 volumes_3d[volume_iterator] = np.union1d(anchors,
-                        top_nodes[tri.faces[face_id]])
+                        top_nodes[source.faces[face_id]])
                 volume_iterator += 1
 
             # lift last node

--- a/gustaf/create/volumes.py
+++ b/gustaf/create/volumes.py
@@ -1,0 +1,95 @@
+"""gustaf/create/volumes.py
+
+Routines to create volumes.
+"""
+
+import numpy as np
+import random
+
+from gustaf.volumes import Volumes
+
+
+def extrude_tri_to_tet(tri, thickness = 1., layers = 1, randomize = False):
+    """
+    Given triangular faces, create three-dimensional tetrahedral volumes.
+
+    The direct extrusion of a triangle is a 6-vertex wedge. This is divided into
+    three tetrahedra.
+
+    The method is deterministic by default. It walks over the flat vertices in
+    given order and lifts them up by create volumes on the surrounding faces.
+    The `randomize` argument will walk through the vertices in random order to
+    create a less structured result. The randomization will be repeated for
+    every layer.
+
+    Parameters
+    ----------
+    tri: Faces
+    thickness: float
+    layers: int
+    randomize: bool
+
+    Returns
+    --------
+    tet: Volumes
+    """
+    if layers < 1:
+        raise ValueError("The number of layers must be >1.")
+
+    if tri.get_whatami() != "tri":
+        raise ValueError(
+            "Input to extrude_tri_to_tet needs to be a tri mesh, but it's "
+            + tri.get_whatami()
+        )
+
+    # nodes
+    number_of_2d_nodes = tri.vertices.shape[0]
+    number_of_3d_nodes = (layers + 1) * number_of_2d_nodes
+    # node coordinates
+    vertices_3d = np.zeros([number_of_3d_nodes, 3])
+    vertices_3d[:,:2] = np.tile(tri.vertices, [layers + 1, 1])
+    vertices_3d[:,2] = np.repeat(np.arange(layers + 1) *
+            thickness, number_of_2d_nodes)
+    # elements
+    number_of_2d_faces = tri.faces.shape[0]
+    number_of_3d_volumes = layers * 3 * number_of_2d_faces
+    volumes_3d = np.zeros([number_of_3d_volumes, 4])
+    # this is an array that maps from a 2d vertex index to the current upper
+    # vertex index. we start with identity.
+    top_nodes = np.arange(number_of_2d_nodes)
+
+    # we need a mapping from nodes to elements
+    node_elements = dict()
+    for vertex_id in range(number_of_2d_nodes):
+        node_elements[vertex_id] = set()
+    for face_index, face in enumerate(tri.faces):
+        for vertex_id in face:
+            node_elements[vertex_id] |= {face_index}
+
+    volume_iterator = 0
+    # loop over 2D (flat) nodes
+    vertex_range = list(range(number_of_2d_nodes))
+    for layer in range(layers):
+        if randomize:
+            random.shuffle(vertex_range)
+        #for flat_vertex_id, face_ids in node_elements.items():
+        for flat_vertex_id in vertex_range:
+            face_ids = node_elements[flat_vertex_id]
+            anchors = {top_nodes[flat_vertex_id], number_of_2d_nodes +
+                    top_nodes[flat_vertex_id]}
+            # loop over node's 2D elements
+            for face_id in face_ids:
+                # remove anchor
+                remaining_nodes = set(tri.faces[face_id]).difference({flat_vertex_id})
+                # add top nodes
+                new_element_nodes = anchors | set(top_nodes[list(remaining_nodes)])
+                # create element
+                volumes_3d[volume_iterator] = list(new_element_nodes)
+                volume_iterator += 1
+
+            # lift last node
+            top_nodes[flat_vertex_id] += number_of_2d_nodes
+
+    tet = Volumes(vertices=vertices_3d, volumes=volumes_3d)
+
+    return tet

--- a/gustaf/create/volumes.py
+++ b/gustaf/create/volumes.py
@@ -67,8 +67,8 @@ def extrude_to_tet(
         thickness = 1.,
         layers = 1,
         randomize = False,
-        bottom_group = "bottom",
-        top_group = "top"
+        bottom_group = "low_z",
+        top_group = "high_z"
         ):
     """
     Given triangular or quadrangular faces, create three-dimensional tetrahedral

--- a/gustaf/create/volumes.py
+++ b/gustaf/create/volumes.py
@@ -61,30 +61,27 @@ def extrude_tri_to_tet(tri, thickness = 1., layers = 1, randomize = False):
     # we need a mapping from nodes to elements
     node_elements = dict()
     for vertex_id in range(number_of_2d_nodes):
-        node_elements[vertex_id] = set()
+        node_elements[vertex_id] = list()
     for face_index, face in enumerate(tri.faces):
         for vertex_id in face:
-            node_elements[vertex_id] |= {face_index}
+            node_elements[vertex_id].append(face_index)
 
     volume_iterator = 0
     # loop over 2D (flat) nodes
-    vertex_range = list(range(number_of_2d_nodes))
+    vertex_range = np.arange(number_of_2d_nodes)
     for layer in range(layers):
         if randomize:
-            random.shuffle(vertex_range)
+            np.random.shuffle(vertex_range)
         #for flat_vertex_id, face_ids in node_elements.items():
         for flat_vertex_id in vertex_range:
             face_ids = node_elements[flat_vertex_id]
-            anchors = {top_nodes[flat_vertex_id], number_of_2d_nodes +
-                    top_nodes[flat_vertex_id]}
+            anchors = np.array([top_nodes[flat_vertex_id], number_of_2d_nodes +
+                    top_nodes[flat_vertex_id]])
             # loop over node's 2D elements
             for face_id in face_ids:
-                # remove anchor
-                remaining_nodes = set(tri.faces[face_id]).difference({flat_vertex_id})
-                # add top nodes
-                new_element_nodes = anchors | set(top_nodes[list(remaining_nodes)])
                 # create element
-                volumes_3d[volume_iterator] = list(new_element_nodes)
+                volumes_3d[volume_iterator] = np.union1d(anchors,
+                        top_nodes[tri.faces[face_id]])
                 volume_iterator += 1
 
             # lift last node
@@ -93,3 +90,4 @@ def extrude_tri_to_tet(tri, thickness = 1., layers = 1, randomize = False):
     tet = Volumes(vertices=vertices_3d, volumes=volumes_3d)
 
     return tet
+

--- a/gustaf/edges.py
+++ b/gustaf/edges.py
@@ -20,7 +20,8 @@ class Edges(Vertices):
         "edges_unique_id",
         "edges_unique_inverse",
         "edges_unique_count",
-        "outlines"
+        "outlines",
+        "edge_groups",
     ]
 
     def __init__(
@@ -47,9 +48,18 @@ class Edges(Vertices):
         self.whatami = "edges"
         self.vis_dict = dict()
         self.vertexdata = dict()
-        self.vertex_groups = utils.groups.VertexGroupCollection(self)
 
+        self.init_groups()
         self.process(everything=process)
+
+    def init_groups(self):
+        """
+        Initialize all group collections.
+
+        This has to be called by all child class constructors.
+        """
+        self.edge_groups = utils.groups.EdgeGroupCollection(self)
+        Vertices.init_groups(self)
 
     def process(
             self,
@@ -192,6 +202,20 @@ class Edges(Vertices):
         _ = self.get_edges_unique()
 
         return self.outlines
+
+    def get_number_of_edges(self):
+        """
+        Returns number of non-unique edges in the mesh.
+
+        Parameters
+        -----------
+        None
+
+        Returns
+        --------
+        number_of_edges: int
+        """
+        return self.edges.shape[0]
 
     def update_elements(self, mask, inplace=True):
         """

--- a/gustaf/edges.py
+++ b/gustaf/edges.py
@@ -416,6 +416,17 @@ class Edges(Vertices):
                 self.get_edges(), self.vertices, edge_group)
         return Edges(edges=group_edges, vertices=group_vertices)
 
+    def extract_all_edge_groups(self):
+        """
+        Extracts all edge groups into independent Edges instances.
+
+        Returns
+        --------
+        meshes: list of Edges
+        """
+        return [self.extract_edge_group(group_name)
+                for group_name in self.edge_groups]
+
     def extract_element_group(self, group_name):
         """
         Extracts a group of elements into an independent mesh instance.
@@ -432,3 +443,16 @@ class Edges(Vertices):
         group_elements, group_vertices = utils.groups.extract_element_group(
                 self.elements(), self.vertices, element_ids)
         return type(self)(elements=group_elements, vertices=group_vertices)
+
+    def extract_all_element_groups(self):
+        """
+        Extracts all element groups into independent mesh instances.
+
+        Returns
+        --------
+        meshes: list of meshes
+        """
+        element_groups = self.get_element_groups()
+        return [self.extract_element_group(group_name)
+                for group_name in element_groups]
+

--- a/gustaf/edges.py
+++ b/gustaf/edges.py
@@ -217,6 +217,18 @@ class Edges(Vertices):
         """
         return self.edges.shape[0]
 
+    def get_element_groups(self):
+        """
+        Returns the element group collection.
+
+        In this case, it returns the edge groups.
+
+        Returns
+        --------
+        edge_groups: EdgeGroupCollection
+        """
+        return self.edge_groups
+
     def update_elements(self, mask, inplace=True):
         """
         Similar to update_vertices, but for elements.
@@ -403,3 +415,20 @@ class Edges(Vertices):
         group_edges, group_vertices = utils.groups.extract_element_group(
                 self.get_edges(), self.vertices, edge_group)
         return Edges(edges=group_edges, vertices=group_vertices)
+
+    def extract_element_group(self, group_name):
+        """
+        Extracts a group of elements into an independent mesh instance.
+
+        Parameters
+        -----------
+        group_name: string
+
+        Returns
+        --------
+        elements: type(self)
+        """
+        element_ids = self.get_element_groups()[group_name]
+        group_elements, group_vertices = utils.groups.extract_element_group(
+                self.elements(), self.vertices, element_ids)
+        return type(self)(elements=group_elements, vertices=group_vertices)

--- a/gustaf/edges.py
+++ b/gustaf/edges.py
@@ -47,6 +47,7 @@ class Edges(Vertices):
         self.whatami = "edges"
         self.vis_dict = dict()
         self.vertexdata = dict()
+        self.vertex_groups = utils.groups.VertexGroupCollection(self)
 
         self.process(everything=process)
 

--- a/gustaf/edges.py
+++ b/gustaf/edges.py
@@ -386,3 +386,20 @@ class Edges(Vertices):
         vertices: Vertices
         """
         return Vertices(self.vertices)
+
+    def extract_edge_group(self, group_name):
+        """
+        Extracts a group of edges into an independent Edges instance.
+
+        Parameters
+        -----------
+        group_name: string
+
+        Returns
+        --------
+        edges: Edges
+        """
+        edge_group = self.edge_groups[group_name]
+        group_edges, group_vertices = utils.groups.extract_element_group(
+                self.get_edges(), self.vertices, edge_group)
+        return Edges(edges=group_edges, vertices=group_vertices)

--- a/gustaf/faces.py
+++ b/gustaf/faces.py
@@ -314,13 +314,8 @@ class Faces(Edges):
         faces: Faces
         """
         face_group = self.face_groups[group_name]
-        group_global_faces = self.get_faces()[face_group]
-        group_global_vertex_ids, group_faces_flat = np.unique(
-                group_global_faces,
-                return_inverse=True)
-        group_vertices = self.vertices[group_global_vertex_ids]
-        group_faces = group_faces_flat.reshape(group_global_faces.shape)
-
+        group_faces, group_vertices = utils.groups.extract_element_group(
+                self.get_faces(), self.vertices, face_group)
         return Faces(faces=group_faces, vertices=group_vertices)
 
 

--- a/gustaf/faces.py
+++ b/gustaf/faces.py
@@ -85,6 +85,20 @@ class Faces(Edges):
 
         return self.whatami
 
+    def get_number_of_faces(self):
+        """
+        Returns number of non-unique faces in the mesh.
+
+        Parameters
+        -----------
+        None
+
+        Returns
+        --------
+        number_of_faces: int
+        """
+        return self.faces.shape[0]
+
     def get_faces(self,):
         """
         Generates edges based on faces and returns.

--- a/gustaf/faces.py
+++ b/gustaf/faces.py
@@ -46,11 +46,19 @@ class Faces(Edges):
         self.whatami = "faces"
         self.vis_dict = dict()
         self.vertexdata = dict()
-        self.vertex_groups = utils.groups.VertexGroupCollection(self)
-        self.face_groups = utils.groups.FaceGroupCollection(self)
         self.BC = dict()
 
+        self.init_groups()
         self.process(process)
+
+    def init_groups(self):
+        """
+        Initialize all group collections.
+
+        This has to be called by all child class constructors.
+        """
+        self.face_groups = utils.groups.FaceGroupCollection(self)
+        Edges.init_groups(self)
 
     def process(
             self,
@@ -88,6 +96,33 @@ class Faces(Edges):
             )
 
         return self.whatami
+
+    def get_number_of_edges(self):
+        """
+        Returns number of non-unique edges in the mesh.
+
+        Parameters
+        -----------
+        None
+
+        Returns
+        --------
+        number_of_edges: int
+        """
+        edges_per_face = 0
+        if self.faces.shape[1] == 3:
+            # triangle
+            edges_per_face = 3
+        elif self.faces.shape[1] == 4:
+            # quadrangle
+            edges_per_face = 4
+        else:
+            raise ValueError(
+                "I have invalid faces array shape. It should be (n, 3) or "
+                f"(n, 4), but I have: {self.volumes.shape}"
+            )
+
+        return edges_per_face * self.faces.shape[0]
 
     def get_number_of_faces(self):
         """

--- a/gustaf/faces.py
+++ b/gustaf/faces.py
@@ -1,5 +1,6 @@
 """gustaf/gustaf/faces.py
 """
+import numpy as np
 
 from gustaf import settings
 from gustaf import utils
@@ -17,6 +18,7 @@ class Faces(Edges):
         "faces_unique_inverse",
         "faces_unique_count",
         "surfaces",
+        "face_groups",
         "BC",
     ]
 
@@ -44,6 +46,8 @@ class Faces(Edges):
         self.whatami = "faces"
         self.vis_dict = dict()
         self.vertexdata = dict()
+        self.vertex_groups = utils.groups.VertexGroupCollection(self)
+        self.face_groups = utils.groups.FaceGroupCollection(self)
         self.BC = dict()
 
         self.process(process)
@@ -261,6 +265,29 @@ class Faces(Edges):
             self.vertices,
             edges=self.get_edges_unique() if unique else self.get_edges()
         )
+
+    def extract_face_group(self, group_name):
+        """
+        Extracts a group of faces into an independent Faces instance.
+
+        Parameters
+        -----------
+        group_name: string
+
+        Returns
+        --------
+        faces: Faces
+        """
+        face_group = self.face_groups[group_name]
+        group_global_faces = self.get_faces()[face_group]
+        group_global_vertex_ids, group_faces_flat = np.unique(
+                group_global_faces,
+                return_inverse=True)
+        group_vertices = self.vertices[group_global_vertex_ids]
+        group_faces = group_faces_flat.reshape(group_global_faces.shape)
+
+        return Faces(faces=group_faces, vertices=group_vertices)
+
 
     #def show(self, BC=False):
         """

--- a/gustaf/faces.py
+++ b/gustaf/faces.py
@@ -356,6 +356,17 @@ class Faces(Edges):
                 self.get_faces(), self.vertices, face_group)
         return Faces(faces=group_faces, vertices=group_vertices)
 
+    def extract_all_face_groups(self):
+        """
+        Extracts all face groups into independent Faces instances.
+
+        Returns
+        --------
+        meshes: list of Faces
+        """
+        return [self.extract_face_group(group_name)
+                for group_name in self.face_groups]
+
     def extract_subelement_group(self, group_name):
         """
         Extracts a group of subelements into an independent mesh instance.
@@ -374,6 +385,18 @@ class Faces(Edges):
         # create instance of parent class
         return type(self).__mro__[1](elements=group_elements,
                 vertices=group_vertices)
+
+    def extract_all_subelement_groups(self):
+        """
+        Extracts all subelement groups into independent mesh instances.
+
+        Returns
+        --------
+        meshes: list of meshes
+        """
+        subelement_groups = self.get_subelement_groups()
+        return [self.extract_subelement_group(group_name)
+                for group_name in subelement_groups]
 
 
     #def show(self, BC=False):

--- a/gustaf/faces.py
+++ b/gustaf/faces.py
@@ -267,6 +267,44 @@ class Faces(Edges):
 
         return self.surfaces
 
+    def get_element_groups(self):
+        """
+        Returns the element group collection.
+
+        In this case, it returns the face groups.
+
+        Returns
+        --------
+        face_groups: FaceGroupCollection
+        """
+        return self.face_groups
+
+    def get_subelement_groups(self):
+        """
+        Returns the subelement group collection.
+
+        Along with vertex groups, this is the most logical place for boundary
+        information in arbitrary dimensions.
+        In this case, it returns the edge groups.
+
+        Returns
+        --------
+        edge_groups: EdgeGroupCollection
+        """
+        return self.edge_groups
+
+    def subelements(self):
+        """
+        Returns the subelement connectivity.
+
+        In this case, it returns the edges.
+
+        Returns
+        --------
+        edges: (ne, nen) np.ndarray
+        """
+        return self.get_edges()
+
     def update_edges(self):
         """
         Just to decouple inherited alias
@@ -317,6 +355,25 @@ class Faces(Edges):
         group_faces, group_vertices = utils.groups.extract_element_group(
                 self.get_faces(), self.vertices, face_group)
         return Faces(faces=group_faces, vertices=group_vertices)
+
+    def extract_subelement_group(self, group_name):
+        """
+        Extracts a group of subelements into an independent mesh instance.
+
+        Parameters
+        -----------
+        group_name: string
+
+        Returns
+        --------
+        elements: super
+        """
+        element_ids = self.get_subelement_groups()[group_name]
+        group_elements, group_vertices = utils.groups.extract_element_group(
+                self.subelements(), self.vertices, element_ids)
+        # create instance of parent class
+        return type(self).__mro__[1](elements=group_elements,
+                vertices=group_vertices)
 
 
     #def show(self, BC=False):

--- a/gustaf/io/mixd.py
+++ b/gustaf/io/mixd.py
@@ -110,6 +110,9 @@ def load(
     # bc
     if len(bcs) != 0:
         mesh.BC = bcs
+        for rng, face_ids in bcs.items():
+            # not using the update() method because that circumvents the checks
+            mesh.face_groups[rng] = face_ids
 
     return mesh
 

--- a/gustaf/show.py
+++ b/gustaf/show.py
@@ -3,6 +3,7 @@
 Everything related to show/visualization.
 """
 from math import prod
+import random
 
 import numpy as np
 
@@ -509,3 +510,46 @@ def interpolate_vedo_dictcam(cameras, resolutions, spline_degree=1):
                 )
 
     return interpolated_cams
+
+def _vedo_make_multicolor(meshes):
+    """
+    Assign alternating colors to meshes for Vedo display.
+
+    Parameters
+    -----------
+    meshes: list of Vertices, Edges, ...
+    """
+    # get color list (omitting 'gray')
+    color_list = [color + str(number)
+            for number in [5] for color in
+            ["blue", "indigo", "purple", "pink", "red", "orange", "yellow",
+                "green", "teal", "cyan"]]
+    random.seed(12)
+    random.shuffle(color_list)
+    random.seed()
+
+    # apply colors
+    for index, mesh in enumerate(meshes):
+        mesh.vis_dict["c"] = color_list[index % len(color_list)]
+
+def group_plot(meshes, shrink=None, multicolor=True):
+    """
+    Plot a group of meshes in the same plot.
+
+    Optionally shrink all elements and colorize different meshes.
+    This only makes adjustments and returns the group for plotting.
+
+    Parameters
+    -----------
+    meshes: list of meshes
+    shrink: float or None
+    multicolor: bool
+    """
+    if shrink:
+        meshes = [mesh.shrink(shrink) for mesh in meshes]
+    if multicolor:
+        _vedo_make_multicolor(meshes)
+
+    return meshes
+
+

--- a/gustaf/utils/__init__.py
+++ b/gustaf/utils/__init__.py
@@ -2,6 +2,7 @@ from gustaf.utils import arr
 from gustaf.utils import connec
 from gustaf.utils import log
 from gustaf.utils import tictoc
+from gustaf.utils import groups
 
 # Alias
 connectivity = connec

--- a/gustaf/utils/connec.py
+++ b/gustaf/utils/connec.py
@@ -302,7 +302,10 @@ def make_quad_faces(resolutions):
     return faces.astype(np.int32)
 
 
-def make_hexa_volumes(resolutions):
+def make_hexa_volumes(
+        resolutions,
+        create_vertex_groups=False
+        ):
     """
     Given number of nodes per each dimension, returns connectivity information 
     of structured hexahedron elements.
@@ -320,6 +323,8 @@ def make_hexa_volumes(resolutions):
     Parameters
     -----------
     resolutions: list
+    create_vertex_groups: bool
+        Create and return vertex groups for all sides. (Default: False)
 
     Returns
     --------
@@ -375,7 +380,18 @@ def make_hexa_volumes(resolutions):
     if (volumes == -1).any():
         raise ValueError("Something went wrong during `make_hexa_volumes`.")
 
-    return volumes.astype(settings.INT_DTYPE)
+    if create_vertex_groups:
+        vertex_groups = dict()
+        vertex_groups["low_x"] = node_indices[:,:,0].flatten()
+        vertex_groups["high_x"] = node_indices[:,:,-1].flatten()
+        vertex_groups["low_y"] = node_indices[:,0,:].flatten()
+        vertex_groups["high_y"] = node_indices[:,-1,:].flatten()
+        vertex_groups["low_z"] = node_indices[0,:,:].flatten()
+        vertex_groups["high_z"] = node_indices[-1,:,:].flatten()
+
+        return volumes.astype(settings.INT_DTYPE), vertex_groups
+    else:
+        return volumes.astype(settings.INT_DTYPE)
 
 
 def subdivide_edges(edges):

--- a/gustaf/utils/connec.py
+++ b/gustaf/utils/connec.py
@@ -266,7 +266,10 @@ def sequence_to_edges(seq, closed=False):
     return edges
 
 
-def make_quad_faces(resolutions):
+def make_quad_faces(
+        resolutions,
+        create_vertex_groups=False
+        ):
     """
     Given number of nodes per each dimension, returns connectivity information 
     of a structured mesh.
@@ -280,6 +283,8 @@ def make_quad_faces(resolutions):
     Parameters
     -----------
     resolutions: list
+    create_vertex_groups: bool
+        Create and return vertex groups for all sides. (Default: False)
 
     Returns
     --------
@@ -299,7 +304,16 @@ def make_quad_faces(resolutions):
     if faces.all() == -1:
         raise ValueError("Something went wrong during `make_quad_faces`.")
 
-    return faces.astype(np.int32)
+    if create_vertex_groups:
+        vertex_groups = dict()
+        vertex_groups["low_x"] = node_indices[:,0].flatten()
+        vertex_groups["high_x"] = node_indices[:,-1].flatten()
+        vertex_groups["low_y"] = node_indices[0,:].flatten()
+        vertex_groups["high_y"] = node_indices[-1,:].flatten()
+
+        return faces.astype(settings.INT_DTYPE), vertex_groups
+    else:
+        return faces.astype(settings.INT_DTYPE)
 
 
 def make_hexa_volumes(

--- a/gustaf/utils/groups.py
+++ b/gustaf/utils/groups.py
@@ -2,6 +2,7 @@
 
 Collection classes for mesh entity groups.
 """
+import copy
 import numpy as np
 
 def element_to_vertex_group(element_connectivity, element_ids):
@@ -80,7 +81,30 @@ def extract_element_group(
 
     return local_connectivity, local_vertices
 
-class VertexGroupCollection(dict):
+class GroupCollectionBase(dict):
+    def __deepcopy__(self, memo):
+        """
+        Create a deepcopy and circumvent checks.
+
+        This makes sure the __setitem__ routine is not called during a deepcopy
+        operation. Otherwise, the checks might fail depending on the copy order.
+
+        Parameters
+        -----------
+        memo : dict(...)
+
+        Returns
+        --------
+        result : type(self)
+        """
+        result = type(self)(self.mesh)
+        for key, value in self.items():
+            result.update({copy.deepcopy(key, memo):
+                copy.deepcopy(value, memo)})
+
+        return result
+
+class VertexGroupCollection(GroupCollectionBase):
     def __init__(self, mesh):
         """
         Constructs vertex group object.
@@ -124,7 +148,7 @@ class VertexGroupCollection(dict):
                 f"Invalid vertex index in vertex group '{group_name}'."
         dict.__setitem__(self, group_name, vertex_ids)
 
-class EdgeGroupCollection(dict):
+class EdgeGroupCollection(GroupCollectionBase):
     def __init__(self, mesh):
         """
         Construct edge group object.
@@ -251,7 +275,7 @@ class EdgeGroupCollection(dict):
             self.mesh.vertex_groups[group_name] = element_to_vertex_group(
                     all_edges, edge_ids)
 
-class FaceGroupCollection(dict):
+class FaceGroupCollection(GroupCollectionBase):
     def __init__(self, mesh):
         """
         Construct face group object.
@@ -378,7 +402,7 @@ class FaceGroupCollection(dict):
             self.mesh.vertex_groups[group_name] = element_to_vertex_group(
                     all_faces, face_ids)
 
-class VolumeGroupCollection(dict):
+class VolumeGroupCollection(GroupCollectionBase):
     def __init__(self, mesh):
         """
         Construct volume group object.

--- a/gustaf/utils/groups.py
+++ b/gustaf/utils/groups.py
@@ -100,10 +100,10 @@ class FaceGroupCollection(dict):
         Convert a vertex group to a face group.
 
         This takes the vertex group specified by `group_name` from the mesh and
-        create a face group that contains all faces whose vertices are in the
+        creates a face group that contains all faces whose vertices are in the
         group.
 
-        Note that this operation is not always unique defined. In contiguous
+        Note that this operation is not always uniquely defined. In contiguous
         surfaces, individual faces could be left out even when all vertices are
         used. This implementation uses a greedy approach that adds all possible
         faces.

--- a/gustaf/utils/groups.py
+++ b/gustaf/utils/groups.py
@@ -1,0 +1,177 @@
+"""gustaf/gustaf/utils/groups.py
+
+Collection classes for mesh entity groups.
+
+So far, vertex and face groups can be stored. Volume and edge groups are
+missing.
+"""
+import numpy as np
+
+class VertexGroupCollection(dict):
+    def __init__(self, mesh):
+        """
+        Constructs vertex group object.
+
+        The vertex group is tied to a specific mesh instance, i.e., an instance
+        of some subclass of Vertices.
+
+        We cannot explicitly check this since that would cause a cyclic
+        dependency.
+
+        Parameters
+        -----------
+        mesh: Vertices
+
+        Returns
+        --------
+        None
+        """
+        self.mesh = mesh
+
+    def __setitem__(self, group_name, vertex_ids):
+        """
+        Add a group to the collection.
+
+        This overrides dict's assignment routine to run some additional checks
+        on the provided data.
+
+        Parameters
+        -----------
+        group_name: str
+        vertex_ids: (n, 1) np.ndarray
+
+        Returns
+        --------
+        None
+        """
+        assert isinstance(vertex_ids, np.ndarray)
+        assert np.issubdtype(vertex_ids.dtype, np.integer)
+        assert vertex_ids.ndim == 1
+        assert np.less(vertex_ids, self.mesh.vertices.shape[0]).all(),\
+                f"Invalid vertex index in vertex group '{group_name}'."
+        dict.__setitem__(self, group_name, vertex_ids)
+
+class FaceGroupCollection(dict):
+    def __init__(self, mesh):
+        """
+        Construct face group object.
+
+        The face group is tied to a specific mesh instance, i.e., either a Faces
+        or Volumes instance.
+
+        We cannot explicitly check this since that would cause a cyclic
+        dependency.
+
+        Parameters
+        -----------
+        mesh: Faces
+
+        Returns
+        --------
+        None
+        """
+        self.mesh = mesh
+
+    def __setitem__(self, group_name, face_ids):
+        """
+        Add a group to the collection.
+
+        This overrides dict's assignment routine to run some additional checks
+        on the provided data.
+
+        Parameters
+        -----------
+        group_name: str
+        face_ids: (n, 1) np.ndarray
+
+        Returns
+        --------
+        None
+        """
+        assert isinstance(face_ids, np.ndarray)
+        assert np.issubdtype(face_ids.dtype, np.integer)
+        assert face_ids.ndim == 1
+        assert np.less(face_ids, self.mesh.get_number_of_faces()).all(),\
+                f"Invalid face index in face group '{group_name}'."
+        dict.__setitem__(self, group_name, face_ids)
+
+    def import_vertex_group(self, group_name):
+        """
+        Convert a vertex group to a face group.
+
+        This takes the vertex group specified by `group_name` from the mesh and
+        create a face group that contains all faces whose vertices are in the
+        group.
+
+        Note that this operation is not always unique defined. In contiguous
+        surfaces, individual faces could be left out even when all vertices are
+        used. This implementation uses a greedy approach that adds all possible
+        faces.
+
+        Parameters
+        -----------
+        group_name: str
+
+        Returns
+        --------
+        None
+        """
+        vertex_group = self.mesh.vertex_groups[group_name]
+        all_faces = self.mesh.get_faces()
+        faces_in_group = np.isin(all_faces, vertex_group).all(axis=1)
+        self[group_name] = faces_in_group.nonzero()[0]
+
+    def import_all_vertex_groups(self):
+        """
+        Take all the vertex groups in the mesh and create corresponding face
+        groups of the same name.
+
+        Parameters
+        -----------
+        None
+
+        Returns
+        --------
+        None
+        """
+        for group_name in self.mesh.vertex_groups:
+            self.import_vertex_group(group_name)
+
+    def export_vertex_group(self, group_name):
+        """
+        Convert a face group to a vertex group.
+
+        This takes the face group specified by `group_name` and creates a group
+        of all vertices that are touched by the faces.
+
+        This implementation creates the complete face connectivity array, even
+        though only a subset would really be required.
+
+        Parameters
+        -----------
+        group_name: str
+
+        Returns
+        --------
+        None
+        """
+        all_faces = self.mesh.get_faces()
+        face_group = self[group_name]
+        self.mesh.vertex_groups[group_name] = np.unique(all_faces[face_group])
+
+    def export_all_vertex_groups(self):
+        """
+        Take all the face groups and add corresponding vertex groups of the same
+        name to the mesh.
+
+        Parameters
+        -----------
+        None
+
+        Returns
+        --------
+        None
+        """
+        for group_name in self:
+            self.export_vertex_group(group_name)
+

--- a/gustaf/utils/groups.py
+++ b/gustaf/utils/groups.py
@@ -48,6 +48,38 @@ def vertex_to_element_group(element_connectivity, vertex_ids):
     element_ids = element_in_group.nonzero()[0]
     return element_ids
 
+def extract_element_group(
+        global_connectivity,
+        global_vertices,
+        global_element_ids
+        ):
+    """
+    Extract a group of elements from a larger group.
+
+    Takes a given global connectivity and vertex arrays and creates reduced
+    local variants for the group defined by `global_element_ids`.
+
+    Parameters
+    -----------
+    global_connectivity: (neg, nn) np.ndarray
+    global_vertices: (nvg, nsd) np.ndarray
+    global_element_ids: (n) np.ndarray
+
+    Returns
+    --------
+    local_connectivity: (nel, nn) np.ndarray
+    local_vertices: (nvl, nsd) np.ndarray
+    """
+    global_connectivity_subset = global_connectivity[global_element_ids]
+    global_vertex_ids_subset, local_connectivity_flat = np.unique(
+            global_connectivity_subset,
+            return_inverse=True)
+    local_vertices = global_vertices[global_vertex_ids_subset]
+    local_connectivity = local_connectivity_flat.reshape(
+            global_connectivity_subset.shape)
+
+    return local_connectivity, local_vertices
+
 class VertexGroupCollection(dict):
     def __init__(self, mesh):
         """

--- a/gustaf/utils/groups.py
+++ b/gustaf/utils/groups.py
@@ -1,9 +1,6 @@
 """gustaf/gustaf/utils/groups.py
 
 Collection classes for mesh entity groups.
-
-So far, vertex and face groups can be stored. Volume and edge groups are
-missing.
 """
 import numpy as np
 
@@ -94,6 +91,133 @@ class VertexGroupCollection(dict):
         assert np.less(vertex_ids, self.mesh.vertices.shape[0]).all(),\
                 f"Invalid vertex index in vertex group '{group_name}'."
         dict.__setitem__(self, group_name, vertex_ids)
+
+class EdgeGroupCollection(dict):
+    def __init__(self, mesh):
+        """
+        Construct edge group object.
+
+        The edge group is tied to a specific mesh instance, i.e., either a
+        Faces, Edges or Volumes instance.
+
+        We cannot explicitly check this since that would cause a cyclic
+        dependency.
+
+        Parameters
+        -----------
+        mesh: Edges
+
+        Returns
+        --------
+        None
+        """
+        self.mesh = mesh
+
+    def __setitem__(self, group_name, edge_ids):
+        """
+        Add a group to the collection.
+
+        This overrides dict's assignment routine to run some additional checks
+        on the provided data.
+
+        Parameters
+        -----------
+        group_name: str
+        edge_ids: (n, 1) np.ndarray
+
+        Returns
+        --------
+        None
+        """
+        assert isinstance(edge_ids, np.ndarray)
+        assert np.issubdtype(edge_ids.dtype, np.integer)
+        assert edge_ids.ndim == 1
+        assert np.less(edge_ids, self.mesh.get_number_of_edges()).all(),\
+                f"Invalid edge index in edge group '{group_name}'."
+        dict.__setitem__(self, group_name, edge_ids)
+
+    def import_vertex_group(self, group_name):
+        """
+        Convert a vertex group to an edge group.
+
+        This takes the vertex group specified by `group_name` from the mesh and
+        creates an edge group that contains all edges whose vertices are in the
+        group.
+
+        Note that this operation is not always uniquely defined. In contiguous
+        regions, individual edges could be left out even when all vertices are
+        used. This implementation uses a greedy approach that adds all possible
+        edges.
+
+        Parameters
+        -----------
+        group_name: str
+
+        Returns
+        --------
+        None
+        """
+        vertex_group = self.mesh.vertex_groups[group_name]
+        all_edges = self.mesh.get_edges()
+        self[group_name] = vertex_to_element_group(all_edges, vertex_group)
+
+    def import_all_vertex_groups(self):
+        """
+        Take all the vertex groups in the mesh and create corresponding edge
+        groups of the same name.
+
+        Parameters
+        -----------
+        None
+
+        Returns
+        --------
+        None
+        """
+        all_edges = self.mesh.get_edges()
+        for group_name, vertex_ids in self.mesh.vertex_groups.items():
+            self[group_name] = vertex_to_element_group(all_edges, vertex_ids)
+
+    def export_vertex_group(self, group_name):
+        """
+        Convert an edge group to a vertex group.
+
+        This takes the edge group specified by `group_name` and creates a group
+        of all vertices that are touched by the edges.
+
+        This implementation creates the complete edge connectivity array, even
+        though only a subset would really be required.
+
+        Parameters
+        -----------
+        group_name: str
+
+        Returns
+        --------
+        None
+        """
+        all_edges = self.mesh.get_edges()
+        edge_group = self[group_name]
+        self.mesh.vertex_groups[group_name] = element_to_vertex_group(
+                all_edges, edge_group)
+
+    def export_all_vertex_groups(self):
+        """
+        Take all the edge groups and add corresponding vertex groups of the same
+        name to the mesh.
+
+        Parameters
+        -----------
+        None
+
+        Returns
+        --------
+        None
+        """
+        all_edges = self.mesh.get_edges()
+        for group_name, edge_ids in self.items():
+            self.mesh.vertex_groups[group_name] = element_to_vertex_group(
+                    all_edges, edge_ids)
 
 class FaceGroupCollection(dict):
     def __init__(self, mesh):
@@ -221,4 +345,130 @@ class FaceGroupCollection(dict):
         for group_name, face_ids in self.items():
             self.mesh.vertex_groups[group_name] = element_to_vertex_group(
                     all_faces, face_ids)
+
+class VolumeGroupCollection(dict):
+    def __init__(self, mesh):
+        """
+        Construct volume group object.
+
+        The volume group is tied to a specific Volumes instance.
+
+        We cannot explicitly check this since that would cause a cyclic
+        dependency.
+
+        Parameters
+        -----------
+        mesh: Volumes
+
+        Returns
+        --------
+        None
+        """
+        self.mesh = mesh
+
+    def __setitem__(self, group_name, volume_ids):
+        """
+        Add a group to the collection.
+
+        This overrides dict's assignment routine to run some additional checks
+        on the provided data.
+
+        Parameters
+        -----------
+        group_name: str
+        volume_ids: (n, 1) np.ndarray
+
+        Returns
+        --------
+        None
+        """
+        assert isinstance(volume_ids, np.ndarray)
+        assert np.issubdtype(volume_ids.dtype, np.integer)
+        assert volume_ids.ndim == 1
+        assert np.less(volume_ids, self.mesh.volumes.shape[0]).all(),\
+                f"Invalid volume index in volume group '{group_name}'."
+        dict.__setitem__(self, group_name, volume_ids)
+
+    def import_vertex_group(self, group_name):
+        """
+        Convert a vertex group to a volume group.
+
+        This takes the vertex group specified by `group_name` from the mesh and
+        creates a volume group that contains all volumes whose vertices are in the
+        group.
+
+        Note that this operation is not always uniquely defined. In contiguous
+        regions, individual volumes could be left out even when all vertices are
+        used. This implementation uses a greedy approach that adds all possible
+        volumes.
+
+        Parameters
+        -----------
+        group_name: str
+
+        Returns
+        --------
+        None
+        """
+        vertex_group = self.mesh.vertex_groups[group_name]
+        all_volumes = self.mesh.volumes
+        self[group_name] = vertex_to_element_group(all_volumes, vertex_group)
+
+    def import_all_vertex_groups(self):
+        """
+        Take all the vertex groups in the mesh and create corresponding volume
+        groups of the same name.
+
+        Parameters
+        -----------
+        None
+
+        Returns
+        --------
+        None
+        """
+        all_volumes = self.mesh.volumes
+        for group_name, vertex_ids in self.mesh.vertex_groups.items():
+            self[group_name] = vertex_to_element_group(all_volumes, vertex_ids)
+
+    def export_vertex_group(self, group_name):
+        """
+        Convert a volume group to a vertex group.
+
+        This takes the volume group specified by `group_name` and creates a group
+        of all vertices that are touched by the volumes.
+
+        This implementation creates the complete volume connectivity array, even
+        though only a subset would really be required.
+
+        Parameters
+        -----------
+        group_name: str
+
+        Returns
+        --------
+        None
+        """
+        all_volumes = self.mesh.volumes
+        volume_group = self[group_name]
+        self.mesh.vertex_groups[group_name] = element_to_vertex_group(
+                all_volumes, volume_group)
+
+    def export_all_vertex_groups(self):
+        """
+        Take all the volume groups and add corresponding vertex groups of the same
+        name to the mesh.
+
+        Parameters
+        -----------
+        None
+
+        Returns
+        --------
+        None
+        """
+        all_volumes = self.mesh.volumes
+        for group_name, volume_ids in self.items():
+            self.mesh.vertex_groups[group_name] = element_to_vertex_group(
+                    all_volumes, volume_ids)
 

--- a/gustaf/utils/groups.py
+++ b/gustaf/utils/groups.py
@@ -7,6 +7,50 @@ missing.
 """
 import numpy as np
 
+def element_to_vertex_group(element_connectivity, element_ids):
+    """
+    Take an element connectivity array and IDs referencing the faces and create
+    a corresponding list of unique vertices.
+
+    Elements could be edges, faces, or volumes.
+
+    Parameters
+    -----------
+    element_connectivity: (ne, nn) np.ndarray
+    element_ids: (n) np.ndarray
+
+    Returns
+    --------
+    vertex_ids: (n) np.ndarray
+    """
+    vertex_ids = np.unique(element_connectivity[element_ids])
+    return vertex_ids
+
+def vertex_to_element_group(element_connectivity, vertex_ids):
+    """
+    Take an element connectivity array and IDs referencing the vertices and
+    create a corresponding list of element IDs that contain all the vertices.
+
+    Note that this operation is not always uniquely defined. In contiguous
+    regions, individual elements could be left out even when all vertices are
+    used. This implementation uses a greedy approach that adds all possible
+    elements.
+
+    Parameters
+    -----------
+    element_connectivity: (ne, nn) np.ndarray
+    vertex_ids: (n) np.ndarray
+
+    Returns
+    --------
+    element_ids: (n) np.ndarray
+    """
+    # create array of booleans that are True for all the elements in the
+    # group
+    element_in_group = np.isin(element_connectivity, vertex_ids).all(axis=1)
+    element_ids = element_in_group.nonzero()[0]
+    return element_ids
+
 class VertexGroupCollection(dict):
     def __init__(self, mesh):
         """
@@ -118,8 +162,7 @@ class FaceGroupCollection(dict):
         """
         vertex_group = self.mesh.vertex_groups[group_name]
         all_faces = self.mesh.get_faces()
-        faces_in_group = np.isin(all_faces, vertex_group).all(axis=1)
-        self[group_name] = faces_in_group.nonzero()[0]
+        self[group_name] = vertex_to_element_group(all_faces, vertex_group)
 
     def import_all_vertex_groups(self):
         """
@@ -134,8 +177,9 @@ class FaceGroupCollection(dict):
         --------
         None
         """
-        for group_name in self.mesh.vertex_groups:
-            self.import_vertex_group(group_name)
+        all_faces = self.mesh.get_faces()
+        for group_name, vertex_ids in self.mesh.vertex_groups.items():
+            self[group_name] = vertex_to_element_group(all_faces, vertex_ids)
 
     def export_vertex_group(self, group_name):
         """
@@ -157,7 +201,8 @@ class FaceGroupCollection(dict):
         """
         all_faces = self.mesh.get_faces()
         face_group = self[group_name]
-        self.mesh.vertex_groups[group_name] = np.unique(all_faces[face_group])
+        self.mesh.vertex_groups[group_name] = element_to_vertex_group(
+                all_faces, face_group)
 
     def export_all_vertex_groups(self):
         """
@@ -172,6 +217,8 @@ class FaceGroupCollection(dict):
         --------
         None
         """
-        for group_name in self:
-            self.export_vertex_group(group_name)
+        all_faces = self.mesh.get_faces()
+        for group_name, face_ids in self.items():
+            self.mesh.vertex_groups[group_name] = element_to_vertex_group(
+                    all_faces, face_ids)
 

--- a/gustaf/vertices.py
+++ b/gustaf/vertices.py
@@ -173,6 +173,17 @@ class Vertices(GustafBase):
         """
         return Vertices(vertices=self.vertices[self.vertex_groups[group_name]])
 
+    def extract_all_vertex_groups(self):
+        """
+        Extracts all vertex groups into independent Vertices instances.
+
+        Returns
+        --------
+        meshes: list of Vertices
+        """
+        return [self.extract_vertex_group(group_name)
+                for group_name in self.vertex_groups]
+
     def get_vertices_unique(
             self,
             tolerance=settings.TOLERANCE,

--- a/gustaf/vertices.py
+++ b/gustaf/vertices.py
@@ -27,6 +27,7 @@ class Vertices(GustafBase):
         "centers",
         "vis_dict",
         "vertexdata",
+        "vertex_groups",
     ]
 
     def __init__(
@@ -52,6 +53,7 @@ class Vertices(GustafBase):
         self.whatami = "vertices"
         self.vis_dict = dict()
         self.vertexdata = dict()
+        self.vertex_groups = utils.groups.VertexGroupCollection(self)
 
     def process(
             self,
@@ -144,6 +146,23 @@ class Vertices(GustafBase):
 
         else:
             return None
+
+    def extract_vertex_group(
+            self,
+            group_name
+    ):
+        """
+        Extracts a vertex group into an independent Vertices instance.
+
+        Parameters
+        -----------
+        group_name: string
+
+        Returns
+        --------
+        group_vertices: Vertices
+        """
+        return Vertices(vertices=self.vertices[self.vertex_groups[group_name]])
 
     def get_vertices_unique(
             self,

--- a/gustaf/vertices.py
+++ b/gustaf/vertices.py
@@ -53,6 +53,15 @@ class Vertices(GustafBase):
         self.whatami = "vertices"
         self.vis_dict = dict()
         self.vertexdata = dict()
+
+        self.init_groups()
+
+    def init_groups(self):
+        """
+        Initialize all group collections.
+
+        This has to be called by all child class constructors.
+        """
         self.vertex_groups = utils.groups.VertexGroupCollection(self)
 
     def process(

--- a/gustaf/volumes.py
+++ b/gustaf/volumes.py
@@ -254,3 +254,21 @@ class Volumes(Faces):
             self.vertices,
             faces=self.get_faces_unique() if unique else self.get_faces()
         )
+
+    def extract_volume_group(self, group_name):
+        """
+        Extracts a group of volumes into an independent Volumes instance.
+
+        Parameters
+        -----------
+        group_name: string
+
+        Returns
+        --------
+        volumes: Volumes
+        """
+        volume_group = self.volume_groups[group_name]
+        group_volumes, group_vertices = utils.groups.extract_element_group(
+                self.volumes, self.vertices, volume_group)
+        return Volumes(volumes=group_volumes, vertices=group_vertices)
+

--- a/gustaf/volumes.py
+++ b/gustaf/volumes.py
@@ -80,6 +80,31 @@ class Volumes(Faces):
 
         return self.whatami
 
+    def get_number_of_faces(self):
+        """
+        Returns number of non-unique faces in the mesh.
+
+        Parameters
+        -----------
+        None
+
+        Returns
+        --------
+        number_of_faces: int
+        """
+        faces_per_volume = 0
+        if self.volumes.shape[1] == 4:
+            faces_per_volume = 4
+        elif self.volumes.shape[1] == 8:
+            faces_per_volume = 6
+        else:
+            raise ValueError(
+                "I have invalid volumes array shape. It should be (n, 4) or "
+                f"(n, 8), but I have: {self.faces.shape}"
+            )
+
+        return faces_per_volume * self.volumes.shape[0]
+
     def update_faces(self):
         """
         """

--- a/gustaf/volumes.py
+++ b/gustaf/volumes.py
@@ -30,6 +30,8 @@ class Volumes(Faces):
         self.whatami = "volumes"
         self.vis_dict = dict()
         self.vertexdata = dict()
+        self.vertex_groups = utils.groups.VertexGroupCollection(self)
+        self.face_groups = utils.groups.FaceGroupCollection(self)
 
         if vertices is not None:
             self.vertices = utils.arr.make_c_contiguous(

--- a/gustaf/volumes.py
+++ b/gustaf/volumes.py
@@ -310,3 +310,14 @@ class Volumes(Faces):
                 self.volumes, self.vertices, volume_group)
         return Volumes(volumes=group_volumes, vertices=group_vertices)
 
+    def extract_all_volume_groups(self):
+        """
+        Extracts all volume groups into independent Volumes instances.
+
+        Returns
+        --------
+        meshes: list of Volumes
+        """
+        return [self.extract_volume_group(group_name)
+                for group_name in self.volume_groups]
+

--- a/gustaf/volumes.py
+++ b/gustaf/volumes.py
@@ -237,6 +237,44 @@ class Volumes(Faces):
 
         return self.volumes_unique_inverse
 
+    def get_element_groups(self):
+        """
+        Returns the element group collection.
+
+        In this case, it returns the volume groups.
+
+        Returns
+        --------
+        volume_groups: VolumeGroupCollection
+        """
+        return self.volume_groups
+
+    def get_subelement_groups(self):
+        """
+        Returns the subelement group collection.
+
+        Along with vertex groups, this is the most logical place for boundary
+        information in arbitrary dimensions.
+        In this case, it returns the face groups.
+
+        Returns
+        --------
+        face_groups: FaceGroupCollection
+        """
+        return self.face_groups
+
+    def subelements(self):
+        """
+        Returns the subelement connectivity.
+
+        In this case, it returns the faces.
+
+        Returns
+        --------
+        faces: (nf, nfn) np.ndarray
+        """
+        return self.get_faces()
+
     def tofaces(self, unique=True):
         """
         Returns Faces obj.


### PR DESCRIPTION
## Related Issues ##

#18 - Storage and maintenance of volume, face and vertex groups

## Description ##

This PR adds vertex groups to Vertices and face groups to Faces. The conversion of vertex to face groups and the other way around is also possible. Furthermore, vertex and face groups can be extracted into independent instances of Vertices and Faces, mostly for display purposes.

The functionality will be demonstrated in the HyperMesh import PR.

## Remarks ##

- The edge and volume groups are missing. If the current draft is approved, they will be added in the same manner, along with `get_element_groups()` and `get_subelement_groups()` getters.
- The function `get_faces()` is heavily used in the current implementation. Does it make sense to check for an existing `faces` array instead? Is that always up-to-date?