### PR TITLE
Harden implementation against mixd loaded meshes

### DIFF
--- a/gustaf/spline/ffd.py
+++ b/gustaf/spline/ffd.py
@@ -128,7 +128,7 @@ class FFD (GustafBase):
             par_dim = mesh.vertices.shape[1]
             self.spline = with_bounds(
                 [[0]*par_dim, [1]*par_dim],
-                mesh.bounds)
+                mesh.get_bounds())
 
         self._logi("Setting mesh.")
         self._logi("Mesh Info:")
@@ -388,7 +388,9 @@ class FFD (GustafBase):
         return_showable: bool
             If true returns a dict of the showable items. Defaults to False.
         return_discrete: bool
-            If true returns a dict of the showable items. Defaults to False.
+            Return dict of gustaf discrete objects, for example,
+            {Vertices, Edges, Faces}, instead of opening a window.
+            Defaults to False.
         kwargs: Any
             Arbitrary keyword arguments. These are passed onto the vedo
             functions. Please be aware, that no checking of these are performed
@@ -459,17 +461,6 @@ class FFD (GustafBase):
             vis_dict.update(
                 deformed_mesh=deformed_dict
             )
-            # return show_vedo(
-            #     ["Original Mesh",
-            #      original_mesh,
-            #      original_mesh.toedges(unique=True)],
-            #     ["Deformed Mesh with Spline",
-            #      #  self.mesh.showable(),
-            #      self.mesh.toedges(unique=True),
-            #      *self._spline.showable().values()],
-            #     title=title, **kwargs
-            # )
-
         if return_discrete or return_showable:
             return vis_dict
         return show_vedo(

--- a/gustaf/spline/ffd.py
+++ b/gustaf/spline/ffd.py
@@ -443,7 +443,7 @@ class FFD (GustafBase):
             )
         else:
             original_dict = {
-                "ffd_title": "Deformed Mesh with Spline",
+                "ffd_title": "Original Mesh",
                 "ffd_mesh": original_mesh,
                 "ffd_mesh_edges": original_mesh.toedges(unique=True)
             }


### PR DESCRIPTION
The `vertices.bounds` attribute is not available after `mixd` import since it is not computed when the mesh is imported. Did not come up in testing since before the mesh was always created in `gustaf`. Have to call `vertices.get_bounds()` to get the actual bounds.