### PR TITLE
tH1: Better import error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,12 @@ gustaf welcomes and appreciates discussions, issues and pull requests!
 Once the repo is forked, one possible starting point would be creating a new python environments, for example, using [conda](https://docs.conda.io/en/latest/miniconda.html) with `python=3.9`
 ```bash
 conda create -n gustafenv python=3.9
+conda activate gustafenv
 git clone git@github.com:<path-to-your-fork>
 cd gustaf
 git checkout -b new-feature0
 python3 setup.py develop
+pip install yapf autopep8 flake8
 ```
 
 ## Style / implementation preferences
@@ -27,6 +29,8 @@ Followings are covered by [auto formatting](https://github.com/tataratat/gustaf/
 
 ### Automatic formatting / style check
 gustaf uses combination of [yapf](https://github.com/google/yapf) and [autopep8](https://github.com/hhatto/autopep8) for automatic formatting. Then [flake8](https://github.com/pycqa/flake8) to double check everything.
+
+To check the format and style of your code use the following commands:
 ```bash
 cd <gustaf-root>
 yapf -i -r gustaf examples tests 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,6 @@ git clone git@github.com:<path-to-your-fork>
 cd gustaf
 git checkout -b new-feature0
 python3 setup.py develop
-pip install yapf autopep8 flake8
 ```
 
 ## Style / implementation preferences
@@ -32,6 +31,7 @@ gustaf uses combination of [yapf](https://github.com/google/yapf) and [autopep8]
 
 To check the format and style of your code use the following commands:
 ```bash
+pip install yapf autopep8 flake8
 cd <gustaf-root>
 yapf -i -r gustaf examples tests 
 autopep8 --select=W291,W292,W293,W504,E265,E501,E711,E722 -r -i --aggressive gustaf examples tests

--- a/gustaf/__init__.py
+++ b/gustaf/__init__.py
@@ -21,7 +21,19 @@ try:
     from gustaf.spline.ffd import FFD
     has_spline = True
 except ImportError:
-    spline = "cannot import spline modules"
+    # overwrites the all modules which depend on the `splinepy` library
+    # with an object which will throw an error
+    # as soon as it is used the first time. This means that any non spline
+    # functionality works as before, but as soon as these are used a
+    # comprehensive exception will be raised which is understandable in
+    # contrast to the possible multitude of errors previously possible
+    from gustaf.helpers.raise_if import ModuleImportRaiser
+    spline = ModuleImportRaiser("splinepy")
+    BSpline = spline
+    NURBS = spline
+    Bezier = spline
+    RationalBezier = spline
+    FFD = spline
 
 # import try/catch for triangle and gustaf-tetgen
 

--- a/gustaf/create/__init__.py
+++ b/gustaf/create/__init__.py
@@ -2,8 +2,15 @@ from gustaf.create import vertices
 
 try:
     from gustaf.create import spline
-except BaseException:
-    pass
+except ImportError as err:
+    # overwrites  all modules which depend on the `splinepy` library
+    # with an object which will throw an error as soon
+    # as it is used the first time. This means that any non spline based
+    # functionality works as before, but as soon as these are used a
+    # comprehensive exception will be raised which is understandable in
+    # contrast to the possible multitude of errors previously possible
+    from gustaf.utils.init_helper import LibraryCanNotBeLoadedHelper
+    spline = LibraryCanNotBeLoadedHelper("splinepy")
 
 __all__ = [
         "vertices",

--- a/gustaf/create/__init__.py
+++ b/gustaf/create/__init__.py
@@ -2,15 +2,15 @@ from gustaf.create import vertices
 
 try:
     from gustaf.create import spline
-except ImportError as err:
+except ImportError:
     # overwrites  all modules which depend on the `splinepy` library
     # with an object which will throw an error as soon
     # as it is used the first time. This means that any non spline based
     # functionality works as before, but as soon as these are used a
     # comprehensive exception will be raised which is understandable in
     # contrast to the possible multitude of errors previously possible
-    from gustaf.utils.init_helper import LibraryCanNotBeLoadedHelper
-    spline = LibraryCanNotBeLoadedHelper("splinepy")
+    from gustaf.helpers.raise_if import ModuleImportRaiser
+    spline = ModuleImportRaiser("splinepy")
 
 __all__ = [
         "vertices",

--- a/gustaf/helpers/raise_if.py
+++ b/gustaf/helpers/raise_if.py
@@ -66,7 +66,7 @@ class ModuleImportRaiser():
         Will notify the user, that the functionality is not accessible and how
         to proceed to access the functionality.
         """
-        if __name == "_LibraryCanNotBeLoadedHelper__message":
+        if __name == "_ModuleImportRaiser__message":
             return object.__getattr__(self, __name[-8:])
         else:
             raise ImportError(self._message)

--- a/gustaf/helpers/raise_if.py
+++ b/gustaf/helpers/raise_if.py
@@ -3,6 +3,7 @@
 Collection of wrapper functions/classes that raises Error with certain
 behavior
 """
+from typing import Any
 
 
 def invalid_inherited_attr(func, qualname, property_=False):
@@ -33,3 +34,58 @@ def invalid_inherited_attr(func, qualname, property_=False):
 
     else:
         return raiser
+
+
+class ModuleImportRaiser():
+    """
+    Class used to have better import error handling in the case that a package
+    package is not installed. This is necessary due to that some packages are
+    not a dependency of `gustaf`, but some parts require them to function.
+    Examples are `splinepy` and `vedo`.
+    """
+
+    def __init__(self, lib_name: str) -> None:
+        self._message = str(
+                "Parts of the requested functionality in gustaf depend on the "
+                f"external `{lib_name}` package which could not be found on "
+                "your system. Please refer to the installation instructions "
+                "for more information."
+        )
+
+    def __call__(self, *args: Any, **kwds: Any) -> Any:
+        """
+        Is called when the object is called by object(). Will notify the user,
+        that the functionality is not accessible and how to proceed to access
+        the functionality.
+        """
+        raise ImportError(self._message)
+
+    def __getattr__(self, __name: str) -> Any:
+        """
+        Is called when any attribute of the object is accessed by object.attr.
+        Will notify the user, that the functionality is not accessible and how
+        to proceed to access the functionality.
+        """
+        if __name == "_LibraryCanNotBeLoadedHelper__message":
+            return object.__getattr__(self, __name[-8:])
+        else:
+            raise ImportError(self._message)
+
+    def __setattr__(self, __name: str, __value: Any) -> None:
+        """
+        Is called when any attribute of the object is set by object.attr = new.
+        Will notify the user, that the functionality is not accessible and how
+        to proceed to access the functionality.
+        """
+        if __name == "_message":
+            object.__setattr__(self, __name, __value)
+        else:
+            raise ImportError(self._message)
+
+    def __getitem__(self, key):
+        """
+        Is called when the object is subscripted object[x]. Will notify the
+        user, that the functionality is not accessible and how to proceed to
+        access the functionality.
+        """
+        raise ImportError(self._message)

--- a/gustaf/show.py
+++ b/gustaf/show.py
@@ -12,7 +12,13 @@ from gustaf._base import GustafBase
 try:
     import vedo
 except ImportError:
-    vedo = "cannot import vedo"
+    # overwrites the vedo module with an object which will throw an error
+    # as soon as it is used the first time. This means that any non vedo
+    # functionality works as before, but as soon as vedo is used a
+    # comprehensive exception will be raised which is understandable in
+    # contrast to the possible errors previously possible
+    from gustaf.helpers.raise_if import ModuleImportRaiser
+    vedo = ModuleImportRaiser("vedo")
 
 
 def show(*gusobj, **kwargs):


### PR DESCRIPTION
#29 

Better import errors when loading splines and `splinepy` is not available and show using vedo when `vedo` is not available, is implemented.

This is done by adding for each class, which if called throws an error. This is advantageous since the error is only thrown if the functionality is actually used and not during the initialization of the package.


Tests would be complicated due to needing different python environments where the packages are not available.