### PR TITLE
FFD splinepy update

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx
-sphinx_rtd_theme
+piccolo-theme
 sphinx-mdinclude
 myst_parser

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,8 +49,8 @@ autodoc_mock_imports = [
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+html_theme = 'piccolo_theme'
 
-html_theme = 'sphinx_rtd_theme'
 # html_static_path = ['_static']
 
 def skip(app, what, name, obj, would_skip, options):

--- a/examples/create_basic_splines.py
+++ b/examples/create_basic_splines.py
@@ -4,7 +4,7 @@ import numpy as np
 if __name__ == '__main__':
 
     line = gus.spline.create.line(np.array([[0, 0, 0], [2, 5, 0], [4, 4, 2]]))
-    rect = gus.spline.create.rectangle(5, 3)
+    rect = gus.spline.create.box(5, 3)
     box = gus.spline.create.box(3, 2, 4)
     pyramid = gus.spline.create.pyramid(1, 1, 2)
 

--- a/examples/show_microstructures.py
+++ b/examples/show_microstructures.py
@@ -3,7 +3,7 @@ import numpy as np
 from vedo import colors, Mesh
 
 # First Test
-generator = gus.spline.microstructure.Generator()
+generator = gus.spline.microstructure.Microstructure()
 generator.deformation_function = gus.Bezier(
         degrees=[2, 1],
         control_points=[[0, 0], [1, 0], [2, -1], [-1, 1], [1, 1], [3, 2]]
@@ -32,7 +32,7 @@ def parametrization_function(x):
     return tuple([.3 - 0.4 * np.maximum(abs(.5 - x[:, 0]), abs(.5 - x[:, 1]))])
 
 
-generator = gus.spline.microstructure.Generator()
+generator = gus.spline.microstructure.Microstructure()
 generator.deformation_function = gus.Bezier(
         degrees=[1, 1], control_points=[[0, 0], [1, 0], [0, 1], [1, 1]]
 )
@@ -48,7 +48,7 @@ generator.show(
 )
 
 # Third test
-generator = gus.spline.microstructure.Generator()
+generator = gus.spline.microstructure.Microstructure()
 generator.deformation_function = gus.Bezier(
         degrees=[1, 1], control_points=[[0, 0], [1, 0], [0, 1], [1, 1]]
 ).create.extruded(extrusion_vector=[0, 0, 1])
@@ -78,7 +78,7 @@ generator.show(
 )
 
 # Fourth test
-generator = gus.spline.microstructure.generator.Generator()
+generator = gus.spline.microstructure.microstructure.Microstructure()
 generator.deformation_function = gus.Bezier(
         degrees=[1, 1], control_points=[[0, 0], [1, 0], [0, 1], [1, 1]]
 ).create.extruded(extrusion_vector=[0, 0, 1])
@@ -92,7 +92,7 @@ generator.show(
 
 # Fifth test
 # Non-uniform tiling
-generator = gus.spline.microstructure.generator.Generator()
+generator = gus.spline.microstructure.microstructure.Microstructure()
 generator.deformation_function = gus.BSpline(
         degrees=[2, 1],
         control_points=[
@@ -130,7 +130,7 @@ def foo(x):
     return tuple([(x[:, 0]) * .05 + (x[:, 1]) * .05 + (x[:, 2]) * .1 + .1])
 
 
-generator = gus.spline.microstructure.Generator()
+generator = gus.spline.microstructure.Microstructure()
 generator.deformation_function = gus.Bezier(
         degrees=[1, 1], control_points=[[0, 0], [1, 0], [0, 1], [1, 1]]
 ).create.extruded(extrusion_vector=[0, 0, 1])

--- a/gustaf/__init__.py
+++ b/gustaf/__init__.py
@@ -20,7 +20,7 @@ try:
     from gustaf.spline.base import BSpline, NURBS, Bezier, RationalBezier
     from gustaf.spline.ffd import FFD
     has_spline = True
-except ImportError:
+except ImportError as err:
     # overwrites the all modules which depend on the `splinepy` library
     # with an object which will throw an error
     # as soon as it is used the first time. This means that any non spline
@@ -28,7 +28,7 @@ except ImportError:
     # comprehensive exception will be raised which is understandable in
     # contrast to the possible multitude of errors previously possible
     from gustaf.helpers.raise_if import ModuleImportRaiser
-    spline = ModuleImportRaiser("splinepy")
+    spline = ModuleImportRaiser("splinepy", err)
     BSpline = spline
     NURBS = spline
     Bezier = spline

--- a/gustaf/create/__init__.py
+++ b/gustaf/create/__init__.py
@@ -2,7 +2,7 @@ from gustaf.create import vertices
 
 try:
     from gustaf.create import spline
-except ImportError:
+except ImportError as err:
     # overwrites  all modules which depend on the `splinepy` library
     # with an object which will throw an error as soon
     # as it is used the first time. This means that any non spline based
@@ -10,7 +10,7 @@ except ImportError:
     # comprehensive exception will be raised which is understandable in
     # contrast to the possible multitude of errors previously possible
     from gustaf.helpers.raise_if import ModuleImportRaiser
-    spline = ModuleImportRaiser("splinepy")
+    spline = ModuleImportRaiser("splinepy", err)
 
 __all__ = [
         "vertices",

--- a/gustaf/helpers/raise_if.py
+++ b/gustaf/helpers/raise_if.py
@@ -3,7 +3,7 @@
 Collection of wrapper functions/classes that raises Error with certain
 behavior
 """
-from typing import Any
+from typing import Any, Optional
 
 
 def invalid_inherited_attr(func, qualname, property_=False):
@@ -47,13 +47,15 @@ class ModuleImportRaiser():
     them to function. Examples are `splinepy` and `vedo`.
     """
 
-    def __init__(self, lib_name: str):
+    def __init__(self, lib_name: str, error_message: Optional[str] = None):
         self._message = str(
-                "Parts of the requested functionality in gustaf depend on the "
-                f"external `{lib_name}` package which could not be found on "
-                "your system. Please refer to the installation instructions "
-                "for more information."
+        "Parts of the requested functionality in gustaf depend on the "
+        f"external `{lib_name}` package which could not be found on "
+        "your system. Please refer to the installation instructions "
+        "for more information. "
+        f"{f'Original error message {error_message}' if error_message else ''}"
         )
+
 
     def __call__(self, *args: Any, **kwds: Any) -> Any:
         """Is called when the object is called by object().

--- a/gustaf/io/mixd.py
+++ b/gustaf/io/mixd.py
@@ -179,7 +179,7 @@ def export(
 
     # write connec
     with open(connec_file, "wb") as cf:
-        for c in (mesh.elements().ravel() + 1):
+        for c in (mesh.elements.ravel() + 1):
             cf.write(struct.pack(big_endian_int, c))
 
     # write bc
@@ -194,7 +194,7 @@ def export(
         # init boundaries with -1, as it is the value for non-boundary.
         # alternatively, they could be (-1 * neighbor_elem_id).
         # But they aren't.
-        boundaries = np.empty(mesh.elements().shape[0] * nbelem, dtype=int)
+        boundaries = np.empty(mesh.elements.shape[0] * nbelem, dtype=int)
         boundaries[:] = -1
 
         for i, belem_ids in enumerate(mesh.BC.values()):
@@ -210,9 +210,9 @@ def export(
 
         st_factor = 2 if space_time else 1
         infof.write(f"nn {int(mesh.vertices.shape[0] * st_factor)}\n")
-        infof.write(f"ne {int(mesh.elements().shape[0])}\n")
+        infof.write(f"ne {int(mesh.elements.shape[0])}\n")
         infof.write(f"nsd {dim}\n")
-        infof.write(f"nen {int(mesh.elements().shape[1] * st_factor)}\n")
+        infof.write(f"nen {int(mesh.elements.shape[1] * st_factor)}\n")
 
         if space_time:
             infof.write("space-time on\n\n\n")

--- a/gustaf/show.py
+++ b/gustaf/show.py
@@ -11,14 +11,14 @@ from gustaf._base import GustafBase
 # @linux it raises error if vedo is imported inside the function.
 try:
     import vedo
-except ImportError:
+except ImportError as err:
     # overwrites the vedo module with an object which will throw an error
     # as soon as it is used the first time. This means that any non vedo
     # functionality works as before, but as soon as vedo is used a
     # comprehensive exception will be raised which is understandable in
     # contrast to the possible errors previously possible
     from gustaf.helpers.raise_if import ModuleImportRaiser
-    vedo = ModuleImportRaiser("vedo")
+    vedo = ModuleImportRaiser("vedo", err)
 
 
 def show(*gusobj, **kwargs):

--- a/gustaf/spline/__init__.py
+++ b/gustaf/spline/__init__.py
@@ -29,7 +29,6 @@ splinepy.settings.NAME_TO_TYPE = dict(
 # a shortcut
 NAME_TO_TYPE = splinepy.settings.NAME_TO_TYPE
 
-
 __all__ = [
         "base",
         "create",

--- a/gustaf/spline/base.py
+++ b/gustaf/spline/base.py
@@ -355,6 +355,7 @@ class Bezier(GustafSpline, splinepy.Bezier):
             self,
             degrees=None,
             control_points=None,
+            spline=None,
     ):
         """Bezier of gustaf. Inherited from splinepy.Bezier and GustafSpline.
 
@@ -373,8 +374,9 @@ class Bezier(GustafSpline, splinepy.Bezier):
         --------
         None
         """
-        super(splinepy.Bezier,
-              self).__init__(degrees=degrees, control_points=control_points)
+        super(splinepy.Bezier, self).__init__(
+                degrees=degrees, control_points=control_points, spline=spline
+        )
 
         self._extractor = Extractor(self)
         self._proximity = Proximity(self)
@@ -455,6 +457,7 @@ class RationalBezier(GustafSpline, splinepy.RationalBezier):
             degrees=None,
             control_points=None,
             weights=None,
+            spline=None,
     ):
         """Rational Bezier of gustaf. Inherited from splinepy.RationalBezier
         and GustafSpline.
@@ -478,7 +481,8 @@ class RationalBezier(GustafSpline, splinepy.RationalBezier):
         super(splinepy.RationalBezier, self).__init__(
                 degrees=degrees,
                 control_points=control_points,
-                weights=weights
+                weights=weights,
+                spline=spline,
         )
 
         self._extractor = Extractor(self)
@@ -529,6 +533,7 @@ class BSpline(GustafSpline, splinepy.BSpline):
             degrees=None,
             knot_vectors=None,
             control_points=None,
+            spline=None,
     ):
         """BSpline of gustaf. Inherited from splinepy.BSpline and GustafSpline.
 
@@ -551,7 +556,8 @@ class BSpline(GustafSpline, splinepy.BSpline):
         super(splinepy.BSpline, self).__init__(
                 degrees=degrees,
                 knot_vectors=knot_vectors,
-                control_points=control_points
+                control_points=control_points,
+                spline=spline,
         )
 
         self._extractor = Extractor(self)
@@ -622,6 +628,7 @@ class NURBS(GustafSpline, splinepy.NURBS):
             knot_vectors=None,
             control_points=None,
             weights=None,
+            spline=None,
     ):
         """NURBS of gustaf. Inherited from splinepy.NURBS.
 
@@ -647,6 +654,7 @@ class NURBS(GustafSpline, splinepy.NURBS):
                 knot_vectors=knot_vectors,
                 control_points=control_points,
                 weights=weights,
+                spline=spline,
         )
 
         self._extractor = Extractor(self)

--- a/gustaf/spline/create.py
+++ b/gustaf/spline/create.py
@@ -1,6 +1,6 @@
 """gustaf/spline/create.py.
 
-Create operations for spline geometries
+Creates splines.
 """
 
 import numpy as np
@@ -255,23 +255,23 @@ def revolved(
     return type(spline)(**spline_dict)
 
 
-def line(points, degree=1):
-    """Create a spline with the provided points as control points with given
-    degree.
+def line(points):
+    """Create a spline with the provided points as control points.
 
     Parameters
     ----------
-    points : numpy.ndarray
+    points: (n, d) numpy.ndarray
       npoints x ndims array of control points
-    degree : int, optional
-      Desired spline degree, by default 1
 
     Returns
     -------
-    gustaf.Bspline
-      Bspline with choosen control points and if necessary internal knots.
+    line: BSpline
+      Spline degree [1].
     """
-    from gustaf import BSpline, Bezier
+    from gustaf import BSpline
+
+    # lines have degree 1
+    degree = 1
 
     cps = np.array(points)
     nknots = cps.shape[0] + degree + 1
@@ -284,21 +284,16 @@ def line(points, degree=1):
             )
     )
 
-    if cps.shape[0] == degree + 1:
-        spline = Bezier(control_points=cps, degrees=[degree])
-    else:
-        spline = BSpline(
-                control_points=cps, knot_vectors=[knots], degrees=[degree]
-        )
+    spline = BSpline(
+            control_points=cps, knot_vectors=[knots], degrees=[degree]
+    )
 
     return spline
 
 
 def arc(radius=1., angle=90., n_knot_spans=None, start_angle=0., degree=True):
     """Creates a 1-D arc as Rational Bezier or NURBS with given radius and
-      angle. The arc lies in the x-y plane and rotates around the z-axis.
-
-
+    angle. The arc lies in the x-y plane and rotates around the z-axis.
 
     Parameters
     ----------
@@ -315,8 +310,7 @@ def arc(radius=1., angle=90., n_knot_spans=None, start_angle=0., degree=True):
 
     Returns
     -------
-    gustaf.NURBS or gustaf.RationalBezier
-        Line spline describing an arc
+    arc: NURBS or RationalBezier
     """
     from gustaf import RationalBezier
 
@@ -346,8 +340,8 @@ def arc(radius=1., angle=90., n_knot_spans=None, start_angle=0., degree=True):
 
 
 def circle(radius=1., n_knot_spans=3):
-    """Line circle with radius r in the x-y plane around the origin.
-    The spline has an open knot vector and degree 2.
+    """Circle (parametric dim = 1) with radius r in the x-y plane around the
+    origin. The spline has an open knot vector and degree 2.
 
     Parameters
     ----------
@@ -358,74 +352,48 @@ def circle(radius=1., n_knot_spans=3):
 
     Returns
     -------
-    gustaf.NURBS
-      Line circle NURBS
+    circle: NURBS
     """
     return arc(radius=radius, angle=360, n_knot_spans=n_knot_spans)
 
 
-def rectangle(width, length):
-    """ Surface spline in rectangluar shape with linear degree.
-    The rectangle lies in the x-y plane with one corner in the origin.
+def box(*lengths):
+    """ND box (hyperrectangle).
 
     Parameters
     ----------
-    width : float
-      dimension of the rectangle in x-direction
-    length : float
-      dimension of the rectangle in y-direction
+    *lengths: list(float)
 
     Returns
     -------
-    gustaf.Bezier
-      Rectangluar Bezier spline with lengths of the sides a and b.
+    ndbox: Bezier
     """
-    from gustaf.spline import Bezier
+    from gustaf import Bezier
 
-    cps = np.zeros([4, 2])
-    cps[1, 0] = width
-    cps[2, 1] = length
-    cps[3, :] = width, length
+    # may dim check here?
 
-    return Bezier(control_points=cps, degrees=[1, 1])
+    # starting point
+    ndbox = Bezier(degrees=[1], control_points=[[0], [lengths[0]]])
+    # use extrude
+    for i, l in enumerate(lengths[1:]):
+        ndbox = ndbox.create.extruded([0] * int(i + 1) + [l])
 
-
-def box(width, length, height):
-    """Volumetric spline with linear degree and dimensions a,b,h in
-    x,y,z-direction
-
-    Parameters
-    ----------
-    width : float
-      dimension of the box in x-direction
-    length : float
-      dimension of the box in y-direction
-    height : float
-      dimension of the box in z-direction
-
-    Returns
-    -------
-    gustaf.Bezier
-      Volumetric linear Bezier spline
-    """
-    return rectangle(width, length).create.extruded([0., 0., height])
+    return ndbox
 
 
 def plate(radius=1.):
     """Creates a biquadratic 2-D spline in the shape of a plate with given
-  radius.
+    radius.
 
-  Parameters
-  ----------
-  radius : float, optional
-    Radius of the plate, defaults to one
+    Parameters
+    ----------
+    radius : float, optional
+      Radius of the plate, defaults to one
 
-  Returns
-  -------
-  gustaf.RationalBezier
-    Surface spline forming plate
-  """
-
+    Returns
+    -------
+    plate: RationalBezier
+    """
     from gustaf.spline import RationalBezier
 
     degrees = [2, 2]
@@ -457,8 +425,8 @@ def disk(
         degree=True
 ):
     """Surface spline describing a potentially hollow disk with quadratic
-    degree along curved dimension and linear along thickness.
-    The angle describes the returned part of the disk.
+    degree along curved dimension and linear along thickness. The angle
+    describes the returned part of the disk.
 
     Parameters
     ----------
@@ -473,7 +441,7 @@ def disk(
 
     Returns
     -------
-    gustaf.NURBS
+    disk: NURBS
       Surface NURBS of degrees (1,2)
     """
 
@@ -504,10 +472,9 @@ def torus(
         torus_n_knot_spans=4,
         degree=True,
 ):
-    """Creates a volumetric NURBS spline describing a torus revolved around
-    the x-axis.
-    Possible cross-sections are plate, disk (yielding a tube) and section of
-    a disk.
+    """Creates a volumetric NURBS spline describing a torus revolved around the
+    x-axis. Possible cross-sections are plate, disk (yielding a tube) and
+    section of a disk.
 
     Parameters
     ----------
@@ -529,7 +496,7 @@ def torus(
 
     Returns
     -------
-    gustaf.NURBS
+    torus: NURBS
       Volumetric spline in the shape of a torus with degrees (1,2,2)
     """
 
@@ -600,7 +567,7 @@ def sphere(
 
     Returns
     -------
-    gustaf.NURBS
+    sphere: NURBS
       Volumetric NURBS with degrees (1,2,2)
     """
 
@@ -615,11 +582,7 @@ def sphere(
     else:
         inner_radius = float(inner_radius)
         sphere = disk(outer_radius, inner_radius).nurbs.create.revolved(
-                # axis=[1, 0, 0],
-                # center=[0, 0, 0],
-                angle=angle,
-                n_knot_spans=n_knot_spans,
-                degree=degree
+                angle=angle, n_knot_spans=n_knot_spans, degree=degree
         )
     return sphere
 
@@ -647,7 +610,7 @@ def cone(
 
     Returns
     -------
-    gustaf.NURBS
+    cone: NURBS
       Volumetric or surface NURBS descibing a cone
     """
 
@@ -671,8 +634,8 @@ def cone(
 
 
 def pyramid(width, length, height):
-    """Creates a volumetric spline in the shape of a pyramid with linear
-    degree in every direction.
+    """Creates a volumetric spline in the shape of a pyramid with linear degree
+    in every direction.
 
     Parameters
     ----------
@@ -685,7 +648,7 @@ def pyramid(width, length, height):
 
     Returns
     -------
-    gustaf.Bspline
+    pyramid: BSpline
       Volumetric linear spline in the shape of a pyramid
     """
 

--- a/gustaf/spline/ffd.py
+++ b/gustaf/spline/ffd.py
@@ -62,16 +62,6 @@ class FFD(GustafBase):
             unscaled base mesh
         _q_vertices: np.ndarray (n, dim)
             Scaled vertices of the base mesh
-        _is_calculated: bool
-            Attribute tracking if changes are present since last calculation
-        _is_calculated_trackable: bool
-            Getter for cp was called. Cps can be changed without knowledge
-            need to recalculate every time.
-        _orig_para_dim_ranges: np.ndarray:
-            Original spline parametric dimension boundaries, used in
-            knot_insertion to scale the knots to be inserted into the same
-            scale as the internal spline (which has a hypercubic parametric
-            dimensional space)
 
         Returns
         -------
@@ -82,16 +72,13 @@ class FFD(GustafBase):
         self._mesh: MESH_TYPES = None
         self._o_mesh: MESH_TYPES = None
         self._q_vertices: np.ndarray = None
-        self._is_calculated: bool = False
-        self._is_calculated_trackable: bool = True
-        self._orig_para_dim_ranges: np.ndarray = None
 
         if spline is not None:
             self.spline = spline
         if mesh is not None:
             self.mesh = mesh
 
-        self._is_calculated = False
+        # self._is_calculated = False
 
     @property
     def mesh(self, ) -> MESH_TYPES:
@@ -132,25 +119,14 @@ class FFD(GustafBase):
         self._logi("Mesh Info:")
         self._logi("  Vertices: {v}.".format(v=mesh.vertices.shape))
         self._logi("  Bounds: {b}.".format(b=mesh.bounds()))
-        self._o_mesh = mesh.copy()  # we keep original copy for visulization
+        self._o_mesh = mesh.copy()  # we keep original copy for visualization
         self._mesh = mesh.copy()  # another copy for current status.
 
-        # Checks dimensions and ranges critical for a correct FFD calculation
-        if not self._spline.para_dim == self._spline.dim:
-            self._logw(
-                    "The parametric and geometric dimensions of the "
-                    "spline are not the same."
-            )
-        if not self._spline.dim == self._mesh.vertices.shape[1]:
-            self._logw(
-                    "The geometric dimensions of the spline and the "
-                    "dimension of the mesh are not the same."
-            )
+        self._check_dimensions()
 
         self._scale_mesh_vertices()
-        self._is_calculated = False
-        # trackable true since cp overwritten since last getter call
-        self._is_calculated_trackable = True
+        if self._spline:
+            self._spline._data["gustaf_ffd_computed"] = False
 
     @property
     def spline(self):
@@ -165,8 +141,7 @@ class FFD(GustafBase):
         --------
         self._spline: Spline
         """
-        self._logd("Returning copy of current spline.")
-        return self._spline.copy() if self._spline is not None else None
+        return self._spline if self._spline is not None else None
 
     @spline.setter
     def spline(self, spline: SPLINE_TYPES):
@@ -182,17 +157,33 @@ class FFD(GustafBase):
         --------
         None
         """
-        self._spline = spline.copy()
-        if "knot_vectors" in spline.required_properties:
-            self._orig_para_dim_ranges = spline.parametric_bounds.T
-            self._spline.normalize_knot_vectors()
-        else:
-            self._orig_para_dim_ranges = [[0, 1]] * spline.para_dim
+        self._spline = spline
 
-        self._logi("Setting Spline.")
-        self._logi("Spline Info:")
-        self._logi(f"  Parametric dimensions: {spline.para_dim}.")
-        self._is_calculated = False
+    def _check_dimensions(self) -> bool:
+        """Checks if the dimension of the spline and the mesh match and 
+
+        Returns:
+            bool: _description_
+        """
+        messages = []
+        # Checks dimensions and ranges critical for a correct FFD calculation
+        if self._spline and not self._spline.para_dim == self._spline.dim:
+            messages.append(
+                "The parametric and geometric dimensions of the "
+                "spline are not the same.")
+        if (
+            self._spline and self._mesh 
+            and not self._spline.dim == self._mesh.vertices.shape[1]
+        ):
+            messages.append(
+                "The geometric dimensions of the spline and the "
+                "dimension of the mesh are not the same."
+            )
+        if len(messages) > 0:
+            raise RuntimeError(
+                "Can not perform FFD due to spline and mesh "
+                "dimension mismatch. The following dimension mismatches exist:"
+                f"{messages}.")
 
     def _scale_mesh_vertices(self):
         """Scales the mesh vertices into the dimension of a hypercube and save
@@ -233,29 +224,32 @@ class FFD(GustafBase):
                     "spline or(and) the mesh are not yet defined. "
                     "Please set either spline or mesh."
             )
-        if self._is_calculated and self._is_calculated_trackable:
-            return None
+        if self._spline._data.get("gustaf_ffd_computed", False):
+           return 
+
+        spline = self._spline.copy()
+        if "knot_vectors" in spline.required_properties:
+            spline.normalize_knot_vectors()
+
+        self._check_dimensions()
 
         self._logd("Applying FFD: Transforming vertices")
 
         # Here, we take _q_vertices, due to possible scale/offset.
-        self._mesh.vertices = self._spline.evaluate(self._q_vertices)
+        self._mesh.vertices = spline.evaluate(self._q_vertices)
         self._logd("FFD successful.")
 
-        self._is_calculated = True
+        self._spline._data["gustaf_ffd_computed"] = True
 
     @property
     def control_points(self):
         """Returns current spline's control points. The control points can be
-        directly updated with this. Please use carefully! After calling this
-        'self._is_calculated' is not trackable anymore so deformation
-        calculation is performed every time.
+        directly updated with this.
 
         Returns
         --------
         self._spline.control_points: np.ndarray
         """
-        self._is_calculated_trackable = False
         return self._spline.control_points
 
     @control_points.setter
@@ -277,9 +271,6 @@ class FFD(GustafBase):
 
         self._spline.control_points = control_points.copy()
         self._logd("Set new control points.")
-        self._is_calculated = False
-        # trackable true since cp overwritten since last getter call
-        self._is_calculated_trackable = True
 
     def elevate_degree(self, *args, **kwargs):
         """Wrapper for Spline.elevate_degree.
@@ -311,12 +302,6 @@ class FFD(GustafBase):
             raise NotImplementedError(
                     "Can not perform knot insertion on Bezier spline."
             )
-        # scale knots from the original bounds into the new bounds
-        dim_bounds = self._orig_para_dim_ranges[parametric_dimension]
-        knots = (
-                (np.array(knots) - dim_bounds[0])
-                / (dim_bounds[-1] - dim_bounds[0])
-        )
         self._spline.insert_knots(parametric_dimension, knots)
 
     def remove_knots(self, parametric_dimension, knots, tolerance=1e-8):
@@ -335,16 +320,9 @@ class FFD(GustafBase):
             raise NotImplementedError(
                     "Can not perform knot insertion on Bezier spline."
             )
-        # scale knots from the original bounds into the new bounds
-        dim_bounds = self._orig_para_dim_ranges[parametric_dimension]
-        knots = (
-                (np.array(knots) - dim_bounds[0])
-                / (dim_bounds[-1] - dim_bounds[0])
-        )
         self._spline.remove_knots(
                 parametric_dimension, knots, tolerance=tolerance
         )
-        self._is_calculated = False
 
     def reduce_degree(self, *args, **kwargs):
         """Wrapper for Spline.reduce_degree.
@@ -359,7 +337,6 @@ class FFD(GustafBase):
         None
         """
         self._spline.reduce_degree(*args, **kwargs)
-        self._is_calculated = False
 
     def show(self, **kwargs) -> Any:
         """Visualize. Shows the deformed mesh and the current spline. Currently

--- a/gustaf/spline/ffd.py
+++ b/gustaf/spline/ffd.py
@@ -141,7 +141,7 @@ class FFD(GustafBase):
         --------
         self._spline: Spline
         """
-        return self._spline if self._spline is not None else None
+        return self._spline
 
     @spline.setter
     def spline(self, spline: SPLINE_TYPES):
@@ -225,10 +225,10 @@ class FFD(GustafBase):
                     "Please set either spline or mesh."
             )
         if self._spline._data.get("gustaf_ffd_computed", False):
-           return 
+           return None
 
         spline = self._spline.copy()
-        if "knot_vectors" in spline.required_properties:
+        if spline.has_knot_vectors:
             spline.normalize_knot_vectors()
 
         self._check_dimensions()

--- a/gustaf/spline/microstructure/__init__.py
+++ b/gustaf/spline/microstructure/__init__.py
@@ -3,8 +3,8 @@
 Interface for tools and generators creating simple microstructures.
 """
 
-from gustaf.spline.microstructure import tiles, generator
+from gustaf.spline.microstructure import tiles, microstructure
 
-from gustaf.spline.microstructure.generator import Generator
+from gustaf.spline.microstructure.microstructure import Microstructure
 
-__all__ = ["tiles", "generator", "Generator"]
+__all__ = ["tiles", "microstructure", "Microstructure"]

--- a/gustaf/spline/microstructure/microstructure.py
+++ b/gustaf/spline/microstructure/microstructure.py
@@ -4,7 +4,7 @@ from gustaf._base import GustafBase
 from gustaf.spline import base
 
 
-class Generator(GustafBase):
+class Microstructure(GustafBase):
     """Helper class to facilitatae the construction of microstructures."""
 
     def __init__(


### PR DESCRIPTION
Also addresses #55. It will append any error message it receives to the end of the default message. Will only display the default message if no error message is given.

The FFD change in that it now does not copy the spline it gets. So it can in theory be adapted directly by the user without overwriting it every time. (A temporary copy is created during the mesh calculation since the knot_vectors are normalized and this should not be done to the user-accessible spline. This spline should only ever live inside the scope of the _deform() method.))