### PR TITLE
Nutils tools

### DIFF
--- a/examples/interfaces/nutils_interface.py
+++ b/examples/interfaces/nutils_interface.py
@@ -71,9 +71,9 @@ def main():
     # (we get simplices, so take number of simplex nodes minus 1)
     n_axes = element_nodes.shape[1] - 1
 
-    # faces or volumes?
-    MeshType = {1: gus.Edges, 2: gus.Faces, 3: gus.Volumes}[n_axes]
-    gustaf_mesh = MeshType(elements=element_nodes, vertices=coordinates)
+    # generate gustaf mesh using information given by nutils
+    mesh_type = {1: gus.Edges, 2: gus.Faces, 3: gus.Volumes}[n_axes]
+    gustaf_mesh = mesh_type(elements=element_nodes, vertices=coordinates)
 
     # with lhs
     deformation = lhs.reshape(m.vertices.shape)

--- a/examples/interfaces/nutils_interface.py
+++ b/examples/interfaces/nutils_interface.py
@@ -3,15 +3,15 @@ from nutils.expression_v2 import Namespace
 
 import gustaf as gus
 import numpy as np
+"""This example shows the funtionality of gustaf.io.nutils.
 
-"""This example shows the funtionality of gustaf.io.nutils. 
-
-A 2-dimensional plate with fixed edges on the left and right edges is 
+A 2-dimensional plate with fixed edges on the left and right edges is
 exposed to Gravitation.
 The plate consists of 20 triangular elements and is created with gustaf.
 One can either add the displacements directly to gustaf.vertices or evalute
 the new coordinates and create a new gustaf.mesh.
 """
+
 
 def main():
     # Simulation parameters
@@ -25,14 +25,9 @@ def main():
     e_mod = 1 * pow(10, 2)
 
     m = define_mesh()
-    
+
     # Define Boundaries by Edges
-    m.BC.update(
-        {
-            '1': np.array([4, 10]),
-            '2': np.array([49, 55])
-        }
-    )
+    m.BC.update({'1': np.array([4, 10]), '2': np.array([49, 55])})
 
     m_in = m.copy()
 
@@ -57,18 +52,17 @@ def main():
     ns.energy = 'lmbda strain_ii strain_jj + 2 mu strain_ij strain_ij'
     ns.energy = 'energy + g rho u_1'
 
-
     # Set the boundaries. Note, that bound-keys start with 1,2,3,..
-    sqr = domain.boundary['1'].integral('u_k u_k dS' @ ns, degree=degree*2)
-    sqr += domain.boundary['2'].integral('u_k u_k dS' @ ns, degree=degree*2)
+    sqr = domain.boundary['1'].integral('u_k u_k dS' @ ns, degree=degree * 2)
+    sqr += domain.boundary['2'].integral('u_k u_k dS' @ ns, degree=degree * 2)
 
     cons = solver.optimize('lhs', sqr, droptol=1e-15)
 
-    energy = domain.integral('energy dV' @ ns, degree=degree*2)
+    energy = domain.integral('energy dV' @ ns, degree=degree * 2)
 
-    lhs = solver.optimize('lhs', energy, constrain=cons)        # displacements
+    lhs = solver.optimize('lhs', energy, constrain=cons)  # displacements
 
-    ## With bezier
+    # With bezier
     bezier = domain.sample('vertex', 0)
     coordinates = bezier.eval('X_i' @ ns, lhs=lhs)
     element_nodes = bezier.tri
@@ -76,79 +70,61 @@ def main():
     # how many axes?
     # (we get simplices, so take number of simplex nodes minus 1)
     n_axes = element_nodes.shape[1] - 1
-    n_elements = element_nodes.shape[0]
 
     # faces or volumes?
     MeshType = {1: gus.Edges, 2: gus.Faces, 3: gus.Volumes}[n_axes]
     gustaf_mesh = MeshType(elements=element_nodes, vertices=coordinates)
 
-    ## with lhs
+    # with lhs
     deformation = lhs.reshape(m.vertices.shape)
     m.vertices += deformation
-  
+
     gus.show.show_vedo(
-        [m_in, "gustaf_input-mesh"], 
-        [m, "gustaf_mesh-with-lhs"], 
-        [gustaf_mesh, "gustaf_mesh-bezier"],
-        c="blue"
+            [m_in, "gustaf_input-mesh"], [m, "gustaf_mesh-with-lhs"],
+            [gustaf_mesh, "gustaf_mesh-bezier"],
+            c="blue"
     )
 
 
 def define_mesh():
 
     v = np.array(
-        [
-            [0., 0.],
-            [0., 1.],
-            [0., 2.],
-            [1., 0.],
-            [1., 1.],
-            [1., 2.],
-            [2., 0.],
-            [2., 1.],
-            [2., 2.],
-            [3., 0.],
-            [3., 1.],
-            [3., 2.],
-            [4., 0.],
-            [4., 1.],
-            [4., 2.],
-            [5., 0.],
-            [5., 1.],
-            [5., 2.],
-        ]   
+            [
+                    [0., 0.],
+                    [0., 1.],
+                    [0., 2.],
+                    [1., 0.],
+                    [1., 1.],
+                    [1., 2.],
+                    [2., 0.],
+                    [2., 1.],
+                    [2., 2.],
+                    [3., 0.],
+                    [3., 1.],
+                    [3., 2.],
+                    [4., 0.],
+                    [4., 1.],
+                    [4., 2.],
+                    [5., 0.],
+                    [5., 1.],
+                    [5., 2.],
+            ]
     )
 
     tf = np.array(
-        [
-            [0, 3, 4],
-            [4, 1, 0],
-            [1, 4, 5],
-            [5, 2, 1],
-            [3, 6, 7],
-            [7, 4, 3],
-            [4, 7, 8],
-            [8, 5, 4],
-            [6, 9, 10],
-            [10, 7, 6],
-            [7, 10, 11],
-            [11, 8, 7],
-            [9, 12, 13],
-            [13, 10, 9],
-            [10, 13, 14],
-            [14, 11, 10],
-            [12, 15, 16],
-            [16, 13, 12],
-            [13, 16, 17],
-            [17, 14, 13]
-        ]   
+            [
+                    [0, 3, 4], [4, 1, 0], [1, 4, 5], [5, 2, 1], [3, 6, 7],
+                    [7, 4, 3], [4, 7, 8], [8, 5, 4], [6, 9, 10], [10, 7, 6],
+                    [7, 10, 11], [11, 8, 7], [9, 12, 13], [13, 10, 9],
+                    [10, 13, 14], [14, 11, 10], [12, 15, 16], [16, 13, 12],
+                    [13, 16, 17], [17, 14, 13]
+            ]
     )
 
-    mesh = gus.Faces(vertices = v, faces = tf)
+    mesh = gus.Faces(vertices=v, faces=tf)
 
     return mesh
 
 
 if __name__ == '__main__':
     main()
-

--- a/examples/interfaces/nutils_interface.py
+++ b/examples/interfaces/nutils_interface.py
@@ -1,0 +1,154 @@
+from nutils import mesh, function, solver
+from nutils.expression_v2 import Namespace
+
+import gustaf as gus
+import numpy as np
+
+"""This example shows the funtionality of gustaf.io.nutils. 
+
+A 2-dimensional plate with fixed edges on the left and right edges is 
+exposed to Gravitation.
+The plate consists of 20 triangular elements and is created with gustaf.
+One can either add the displacements directly to gustaf.vertices or evalute
+the new coordinates and create a new gustaf.mesh.
+"""
+
+def main():
+    # Simulation parameters
+    degree = 1
+    btype = "std"
+
+    # Physical Parameters
+    g = 9.81
+    poisson = 0.4
+    rho = 1.2
+    e_mod = 1 * pow(10, 2)
+
+    m = define_mesh()
+    
+    # Define Boundaries by Edges
+    m.BC.update(
+        {
+            '1': np.array([4, 10]),
+            '2': np.array([49, 55])
+        }
+    )
+
+    m_in = m.copy()
+
+    to_nutils = gus.io.nutils.to_nutils_simplex(m)
+    domain, geom = mesh.simplex(**to_nutils)
+
+    # Define the Namespace for Nutils Simulation
+    ns = Namespace()
+    ns.g = g
+    ns.rho = rho
+    ns.x = geom
+
+    ns.define_for('x', gradient='∇', normal='n', jacobians=('dV', 'dS'))
+    ns.ubasis = domain.basis(btype, degree=degree).vector(2)
+    ns.u = function.dotarg('lhs', ns.ubasis)
+    ns.X_i = 'x_i + u_i'
+
+    ns.lmbda = (e_mod * poisson) / (1 + poisson) / (1 - 2 * poisson)
+    ns.mu = e_mod / (1 + poisson)
+
+    ns.strain_ij = '(∇_j(u_i) + ∇_i(u_j)) / 2'
+    ns.energy = 'lmbda strain_ii strain_jj + 2 mu strain_ij strain_ij'
+    ns.energy = 'energy + g rho u_1'
+
+
+    # Set the boundaries. Note, that bound-keys start with 1,2,3,..
+    sqr = domain.boundary['1'].integral('u_k u_k dS' @ ns, degree=degree*2)
+    sqr += domain.boundary['2'].integral('u_k u_k dS' @ ns, degree=degree*2)
+
+    cons = solver.optimize('lhs', sqr, droptol=1e-15)
+
+    energy = domain.integral('energy dV' @ ns, degree=degree*2)
+
+    lhs = solver.optimize('lhs', energy, constrain=cons)        # displacements
+
+    ## With bezier
+    bezier = domain.sample('vertex', 0)
+    coordinates = bezier.eval('X_i' @ ns, lhs=lhs)
+    element_nodes = bezier.tri
+
+    # how many axes?
+    # (we get simplices, so take number of simplex nodes minus 1)
+    n_axes = element_nodes.shape[1] - 1
+    n_elements = element_nodes.shape[0]
+
+    # faces or volumes?
+    MeshType = {1: gus.Edges, 2: gus.Faces, 3: gus.Volumes}[n_axes]
+    gustaf_mesh = MeshType(elements=element_nodes, vertices=coordinates)
+
+    ## with lhs
+    deformation = lhs.reshape(m.vertices.shape)
+    m.vertices += deformation
+  
+    gus.show.show_vedo(
+        [m_in, "gustaf_input-mesh"], 
+        [m, "gustaf_mesh-with-lhs"], 
+        [gustaf_mesh, "gustaf_mesh-bezier"],
+        c="blue"
+    )
+
+
+def define_mesh():
+
+    v = np.array(
+        [
+            [0., 0.],
+            [0., 1.],
+            [0., 2.],
+            [1., 0.],
+            [1., 1.],
+            [1., 2.],
+            [2., 0.],
+            [2., 1.],
+            [2., 2.],
+            [3., 0.],
+            [3., 1.],
+            [3., 2.],
+            [4., 0.],
+            [4., 1.],
+            [4., 2.],
+            [5., 0.],
+            [5., 1.],
+            [5., 2.],
+        ]   
+    )
+
+    tf = np.array(
+        [
+            [0, 3, 4],
+            [4, 1, 0],
+            [1, 4, 5],
+            [5, 2, 1],
+            [3, 6, 7],
+            [7, 4, 3],
+            [4, 7, 8],
+            [8, 5, 4],
+            [6, 9, 10],
+            [10, 7, 6],
+            [7, 10, 11],
+            [11, 8, 7],
+            [9, 12, 13],
+            [13, 10, 9],
+            [10, 13, 14],
+            [14, 11, 10],
+            [12, 15, 16],
+            [16, 13, 12],
+            [13, 16, 17],
+            [17, 14, 13]
+        ]   
+    )
+
+    mesh = gus.Faces(vertices = v, faces = tf)
+
+    return mesh
+
+
+if __name__ == '__main__':
+    main()
+

--- a/examples/mixd_to_nutils.py
+++ b/examples/mixd_to_nutils.py
@@ -1,0 +1,66 @@
+import gustaf as gus
+import numpy as np
+from nutils import mesh
+
+def main():
+
+    #Creates a gustaf volume.
+    mesh = create_mesh()
+
+    #Export it as .mixd-file and .npz-file
+    gus.io.mixd.export(mesh, "export/export_mixd.xns")
+    gus.io.nutils.export(mesh, "export/export_npz.npz")
+
+    #Load the mixd-file and the .npz-file
+    mesh_mixd = gus.io.mixd.load(
+        volume=True,
+        mxyz="export/export_mixd.mxyz",
+        mien="export/export_mixd.mien",
+        mrng="export/export_mixd.mrng"
+    )
+    mesh_npz = gus.io.nutils.load("export/export_npz.npz")
+
+    mesh.show()
+    mesh_mixd.show()  
+    mesh_npz.show()
+
+def create_mesh():
+    # define coordinates
+    v = np.array(
+            [
+                    [0., 0., 0.],
+                    [1., 0., 0.],
+                    [0., 1., 0.],
+                    [1., 1., 0.],
+                    [0., 0., 1.],
+                    [1., 0., 1.],
+                    [0., 1., 1.],
+                    [1., 1., 1.],
+            ]
+    )
+    # define tet connectivity
+    tv = np.array(
+            [
+                    [0, 2, 7, 3],
+                    [0, 2, 6, 7],
+                    [0, 6, 4, 7],
+                    [5, 0, 4, 7],
+                    [5, 0, 7, 1],
+                    [7, 0, 3, 1],
+            ]
+    )
+    # define hexa connectivity
+    hv = np.array([[0, 1, 3, 2, 4, 5, 7, 6]])
+
+    # init tet
+    tet = gus.Volumes(
+            vertices=v,
+            volumes=tv,
+    )
+
+    return tet
+
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mixd_to_nutils.py
+++ b/examples/mixd_to_nutils.py
@@ -1,28 +1,28 @@
 import gustaf as gus
 import numpy as np
-from nutils import mesh
+
 
 def main():
-
-    #Creates a gustaf volume.
+    # Creates a gustaf volume.
     mesh = create_mesh()
 
-    #Export it as .mixd-file and .npz-file
+    # Export it as .mixd-file and .npz-file
     gus.io.mixd.export(mesh, "export/export_mixd.xns")
     gus.io.nutils.export(mesh, "export/export_npz.npz")
 
-    #Load the mixd-file and the .npz-file
+    # Load the mixd-file and the .npz-file
     mesh_mixd = gus.io.mixd.load(
-        volume=True,
-        mxyz="export/export_mixd.mxyz",
-        mien="export/export_mixd.mien",
-        mrng="export/export_mixd.mrng"
+            volume=True,
+            mxyz="export/export_mixd.mxyz",
+            mien="export/export_mixd.mien",
+            mrng="export/export_mixd.mrng"
     )
     mesh_npz = gus.io.nutils.load("export/export_npz.npz")
 
     mesh.show()
-    mesh_mixd.show()  
+    mesh_mixd.show()
     mesh_npz.show()
+
 
 def create_mesh():
     # define coordinates
@@ -49,8 +49,6 @@ def create_mesh():
                     [7, 0, 3, 1],
             ]
     )
-    # define hexa connectivity
-    hv = np.array([[0, 1, 3, 2, 4, 5, 7, 6]])
 
     # init tet
     tet = gus.Volumes(
@@ -59,7 +57,6 @@ def create_mesh():
     )
 
     return tet
-
 
 
 if __name__ == "__main__":

--- a/examples/mixd_to_nutils.py
+++ b/examples/mixd_to_nutils.py
@@ -20,10 +20,10 @@ def main():
     mesh_npz = gus.io.nutils.load("export/export_npz.npz")
 
     gus.show.show_vedo(
-        ["gustaf-mesh", mesh], 
-        ["mixd-mesh", mesh_mixd], 
-        ["npz-mesh", mesh_npz],
-        )
+            ["gustaf-mesh", mesh],
+            ["mixd-mesh", mesh_mixd],
+            ["npz-mesh", mesh_npz],
+    )
 
 
 def create_mesh():

--- a/examples/mixd_to_nutils.py
+++ b/examples/mixd_to_nutils.py
@@ -19,9 +19,11 @@ def main():
     )
     mesh_npz = gus.io.nutils.load("export/export_npz.npz")
 
-    mesh.show()
-    mesh_mixd.show()
-    mesh_npz.show()
+    gus.show.show_vedo(
+        ["gustaf-mesh", mesh], 
+        ["mixd-mesh", mesh_mixd], 
+        ["npz-mesh", mesh_npz],
+        )
 
 
 def create_mesh():

--- a/gustaf/io/__init__.py
+++ b/gustaf/io/__init__.py
@@ -10,6 +10,7 @@ from gustaf.io import mfem
 from gustaf.io import meshio
 from gustaf.io import mixd
 from gustaf.io import nutils
+from gustaf.io.default import load
 
 __all__ = [
         "ioutils",
@@ -17,4 +18,5 @@ __all__ = [
         "meshio",
         "mixd",
         "nutils",
+        "load",
 ]

--- a/gustaf/io/__init__.py
+++ b/gustaf/io/__init__.py
@@ -9,6 +9,12 @@ from gustaf.io import ioutils
 from gustaf.io import mfem
 from gustaf.io import meshio
 from gustaf.io import mixd
-from gustaf.io.default import load
+from gustaf.io import nutils
 
-__all__ = ["ioutils", "mfem", "meshio", "mixd", "load"]
+__all__ = [
+        "ioutils",
+        "mfem",
+        "meshio",
+        "mixd",
+        "nutils",
+]

--- a/gustaf/io/mixd.py
+++ b/gustaf/io/mixd.py
@@ -42,6 +42,10 @@ def load(
       Default is None.
     mrng: str
       Default is None. This is optional.
+
+    Returns
+    --------
+    mesh: Faces or Volumes
     """
     # figure out input type
     specified_input = mxyz is not None  # bare minimum input

--- a/gustaf/io/mixd.py
+++ b/gustaf/io/mixd.py
@@ -213,6 +213,7 @@ def export(
         # signature
         infof.write("\n\n\n# MIXD generated using `gustaf`.\n")
 
+
 def make_mrng(mesh):
     """
     Builds and return mrng array based on `mesh.BC`
@@ -237,7 +238,7 @@ def make_mrng(mesh):
         nbelem += 1
     elif whatami.startswith("hexa"):
         nbelem += 3
-        
+
     # init boundaries with -1, as it is the value for non-boundary.
     # alternatively, they could be (-1 * neighbor_elem_id).
     # But they aren't.
@@ -245,6 +246,6 @@ def make_mrng(mesh):
     boundaries[:] = -1
 
     for i, belem_ids in enumerate(mesh.BC.values()):
-        boundaries[belem_ids] = i + 1 # bid starts at 1
+        boundaries[belem_ids] = i + 1  # bid starts at 1
 
     return boundaries

--- a/gustaf/io/mixd.py
+++ b/gustaf/io/mixd.py
@@ -184,21 +184,7 @@ def export(
 
     # write bc
     with open(bc_file, "wb") as bf:
-        nbelem = 3
-
-        if whatami.startswith("quad") or whatami.startswith("tet"):
-            nbelem += 1
-        elif whatami.startswith("hexa"):
-            nbelem += 3
-
-        # init boundaries with -1, as it is the value for non-boundary.
-        # alternatively, they could be (-1 * neighbor_elem_id).
-        # But they aren't.
-        boundaries = np.empty(mesh.elements.shape[0] * nbelem, dtype=int)
-        boundaries[:] = -1
-
-        for i, belem_ids in enumerate(mesh.BC.values()):
-            boundaries[belem_ids] = i + 1  # bid starts at 1
+        boundaries = make_mrng(mesh)
 
         for b in boundaries:
             bf.write(struct.pack(big_endian_int, b))
@@ -226,3 +212,39 @@ def export(
 
         # signature
         infof.write("\n\n\n# MIXD generated using `gustaf`.\n")
+
+def make_mrng(mesh):
+    """
+    Builds and return mrng array based on `mesh.BC`
+    Supports `Faces` and `Volumes`.
+
+    Parameters
+    -----------
+    mesh: Faces or Volumes
+      Number of participating elements
+
+    Returns
+    --------
+    boundaries : ndarray
+      The mrng-array.
+    """
+
+    # determine number of subelements
+    whatami = mesh.whatami
+    nbelem = 3
+
+    if whatami.startswith("quad") or whatami.startswith("tet"):
+        nbelem += 1
+    elif whatami.startswith("hexa"):
+        nbelem += 3
+        
+    # init boundaries with -1, as it is the value for non-boundary.
+    # alternatively, they could be (-1 * neighbor_elem_id).
+    # But they aren't.
+    boundaries = np.empty(mesh.elements.shape[0] * nbelem, dtype=int)
+    boundaries[:] = -1
+
+    for i, belem_ids in enumerate(mesh.BC.values()):
+        boundaries[belem_ids] = i + 1 # bid starts at 1
+
+    return boundaries

--- a/gustaf/io/nutils.py
+++ b/gustaf/io/nutils.py
@@ -7,7 +7,6 @@ import numpy as np
 from gustaf.faces import Faces
 from gustaf.volumes import Volumes
 from gustaf.io.ioutils import abs_fname, check_and_makedirs
-from gustaf.utils import log
 from gustaf.io import mixd
 
 
@@ -20,6 +19,10 @@ def load(fname):
     fname: str
       The npz file needs the following keys:
       nodes, cnodes, coords, tags, btags, ptags.
+
+    Returns
+    --------
+    mesh: Faces or Volumes
     """
     npzfile = np.load(fname, allow_pickle=True)
     nodes = npzfile['nodes']
@@ -50,9 +53,11 @@ def load(fname):
         ncol = int(3) if simplex and not volume else int(4)
         connec = connec.reshape(-1, ncol)
         mesh = Volumes(vertices, connec) if volume else Faces(vertices, connec)
-    except:
-        raise RuntimeError("""Can not generate a mesh from the nutils input. 
-            Check nutils mesh description.""")
+    except BaseException:
+        raise RuntimeError(
+                "Can not generate a mesh from the nutils input."
+                "Check nutils mesh description."
+        )
 
     mesh.BC = btags
     return mesh

--- a/gustaf/io/nutils.py
+++ b/gustaf/io/nutils.py
@@ -58,7 +58,7 @@ def load(fname):
     mesh.BC = btags
     return mesh
 
-def export(fname, mesh):
+def export(mesh, fname):
     """
     Export in Nutils format. Files are saved as np.savez().
     Supports triangle,and tetrahedron Meshes.

--- a/gustaf/io/nutils.py
+++ b/gustaf/io/nutils.py
@@ -1,4 +1,4 @@
-"""gustaf/gustaf/io/nutils.py
+"""gustaf/gustaf/io/nutils.py.
 
 io functions for nutils.
 """
@@ -80,7 +80,7 @@ def export(mesh, fname):
 
 def to_nutils_simplex(mesh):
     """Converts a Gustaf_Mesh to a Dictionary, which can be interpreted
-    by nutils.mesh.simplex(**to_nutils_simplex(mesh)). Only work for
+    by ``nutils.mesh.simplex(**to_nutils_simplex(mesh))``. Only work for
     Triangles and Tetrahedrons!
 
     Parameters

--- a/gustaf/io/nutils.py
+++ b/gustaf/io/nutils.py
@@ -1,10 +1,9 @@
 """gustaf/gustaf/io/nutils.py
+
 io functions for nutils.
 """
 
 import os
-import struct
-
 import numpy as np
 
 from gustaf.vertices import Vertices
@@ -15,8 +14,7 @@ from gustaf.utils import log
 from gustaf.io import mixd
 
 def load(fname):
-    """
-    nutils load.
+    """nutils load.
     Loads a nutils (np.savez) file and returns a Gustaf Mesh.
 
     Parameters
@@ -59,8 +57,7 @@ def load(fname):
     return mesh
 
 def export(mesh, fname):
-    """
-    Export in Nutils format. Files are saved as np.savez().
+    """Export in Nutils format. Files are saved as np.savez().
     Supports triangle,and tetrahedron Meshes.
 
     Parameters
@@ -83,8 +80,7 @@ def export(mesh, fname):
 
 
 def to_nutils_simplex(mesh):
-    """
-    Converts a Gustaf_Mesh to a Dictionary, which can be interpreted
+    """Converts a Gustaf_Mesh to a Dictionary, which can be interpreted
     by nutils.mesh.simplex(**to_nutils_simplex(mesh)). Only work for 
     Triangles and Tetrahedrons!
 

--- a/gustaf/io/nutils.py
+++ b/gustaf/io/nutils.py
@@ -1,0 +1,152 @@
+"""gustaf/gustaf/io/nutils.py
+io functions for nutils.
+"""
+
+import os
+import struct
+
+import numpy as np
+
+from gustaf.vertices import Vertices
+from gustaf.faces import Faces
+from gustaf.volumes import Volumes
+from gustaf.io.ioutils import abs_fname, check_and_makedirs
+from gustaf.utils import log
+from gustaf.io import mixd
+
+def load(fname):
+    """
+    nutils load.
+    Loads a nutils (np.savez) file and returns a Gustaf Mesh.
+
+    Parameters
+    -----------
+    fname: str
+      The npz file needs the following keys: 
+      nodes, cnodes, coords, tags, btags, ptags.
+    """
+    npzfile = np.load(fname, allow_pickle=True)
+    nodes = npzfile['nodes']
+    cnodes = npzfile['cnodes']
+    coords = npzfile['coords']
+    tags = npzfile['tags'].item()
+    btags = npzfile['btags'].item()
+    ptags = npzfile['ptags'].item()
+
+    vertices = coords
+
+    # connec
+    simplex = True
+    connec = None
+
+    if vertices.shape[1]==2:
+        volume = False 
+    else:
+        volume = True
+
+    try:
+        connec = nodes
+    except:
+        log.debug("Error")
+
+    # reshape connec
+    if connec is not None:
+        ncol = int(3) if simplex and not volume else int(4)
+        connec = connec.reshape(-1, ncol)
+        mesh = Volumes(vertices, connec) if volume else Faces(vertices, connec)
+
+    mesh.BC = btags
+    return mesh
+
+def export(fname, mesh):
+    """
+    Export in Nutils format. Files are saved as np.savez().
+    Supports triangle,and tetrahedron Meshes.
+
+    Parameters
+    -----------
+    mesh: Faces or Volumes
+    fname: str
+
+    Returns
+    --------
+    None
+    """
+
+    dic = to_nutils_simplex(mesh)
+
+    # prepare export location
+    fname = abs_fname(fname)
+    check_and_makedirs(fname)
+
+    np.savez(fname, **dic)
+
+
+def to_nutils_simplex(mesh):
+    """
+    Converts a Gustaf_Mesh to a Dictionary, which can be interpreted
+    by nutils.mesh.simplex(**to_nutils_simplex(mesh)). Only work for 
+    Triangles and Tetrahedrons!
+
+    Parameters
+    -----------
+    mesh: Faces or Volumes
+
+    Returns
+    --------
+    dic_to_nutils: dict
+    """
+
+    vertices = mesh.vertices
+    faces = mesh.faces
+    whatami = mesh.whatami
+
+    #In 2D, element = face. In 3D, element = volume.
+    if whatami.startswith("tri"):
+        dimension = 2
+        permutation = [1,2,0]
+        elements = faces
+    elif whatami.startswith("tet"):
+        dimension = 3
+        permutation = [2,3,1,0]
+        volumes = mesh.volumes				
+        elements = volumes     
+    else:
+        raise TypeError('Only Triangle and Tetrahedrons are accepted.') 
+
+    dic_to_nutils = dict()
+    
+    #Sort the Node IDs for each Element. 
+    elements_sorted = np.sort(elements, axis=1)
+
+    #Let`s get the Boundaries
+    bcs = dict()
+    bcs_in = mixd.make_mrng(mesh)	
+    bcs_in = np.ndarray.reshape(
+           bcs_in,
+           (int(len(bcs_in)/(dimension + 1)),(dimension + 1)))
+
+    bound_id = np.unique(bcs_in)
+    bound_id = bound_id[bound_id > 0]
+
+    #Reorder the mrng according to nutils permutation: swap collumns
+    bcs_in[:,:] = bcs_in[:,permutation]	
+        
+    #Let's reorder the bcs file with the sort_array
+    bcs_sorted = np.sort(bcs_in, axis = 1)
+        
+    for bi in bound_id:
+        bcs[str(bi)] = np.argwhere(bcs_sorted == bi)
+
+    dic_to_nutils.update(   
+        {   'nodes'     :   elements_sorted,
+            'cnodes'    :   elements_sorted,
+            'coords'    :   vertices,
+            'tags'      :   {},
+            'btags'     :   bcs,
+            'ptags'     :   {}
+        }   
+    )
+
+    return dic_to_nutils
+


### PR DESCRIPTION
## Related issues
following PR to #16
#7 relates to a new tool for gustaf - nutils conversions

## Description
This PR extends ```gustaf.io``` by a ```nutils``` tool. It can load and export simplex meshes (triangle and tetrahedron) from Gustaf to Nutils (https://nutils.org/) and vice versa. Functions can be called by

```
    load(fname)
    export(mesh, fname)
    to_nutils_simplex(mesh)
```
A ```io.mixd``` adaption was necessary. The new function ```as_mrng``` returns a mrng-like file. A small example is provided.