### PR TITLE
block meshing

### DIFF
--- a/examples/create_block_mesh.py
+++ b/examples/create_block_mesh.py
@@ -1,0 +1,20 @@
+import gustaf as gus
+import numpy as np
+
+def main():
+
+    mesh_faces = gus.create.faces.quad_block_mesh(        
+        bounds = [[0, 0], [2, 2]],
+        resolutions = [2, 3])
+
+    mesh_volumes = gus.create.volumes.hexa_block_mesh(
+        bounds = [[0., 0., 0.], [1., 1., 1.]],
+        resolutions = [2, 3, 4]
+    )
+
+    mesh_faces.show()
+    mesh_volumes.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/create_block_mesh.py
+++ b/examples/create_block_mesh.py
@@ -1,15 +1,14 @@
 import gustaf as gus
-import numpy as np
+
 
 def main():
 
-    mesh_faces = gus.create.faces.quad_block_mesh(        
-        bounds = [[0, 0], [2, 2]],
-        resolutions = [2, 3])
+    mesh_faces = gus.create.faces.quad_block_mesh(
+            bounds=[[0, 0], [2, 2]], resolutions=[2, 3]
+    )
 
     mesh_volumes = gus.create.volumes.hexa_block_mesh(
-        bounds = [[0., 0., 0.], [1., 1., 1.]],
-        resolutions = [2, 3, 4]
+            bounds=[[0., 0., 0.], [1., 1., 1.]], resolutions=[2, 3, 4]
     )
 
     mesh_faces.show()

--- a/examples/create_block_mesh.py
+++ b/examples/create_block_mesh.py
@@ -3,11 +3,11 @@ import gustaf as gus
 
 def main():
 
-    mesh_faces = gus.create.faces.quad_block_mesh(
+    mesh_faces = gus.create.faces.box(
             bounds=[[0, 0], [2, 2]], resolutions=[2, 3]
     )
 
-    mesh_volumes = gus.create.volumes.hexa_block_mesh(
+    mesh_volumes = gus.create.volumes.box(
             bounds=[[0., 0., 0.], [1., 1., 1.]], resolutions=[2, 3, 4]
     )
 

--- a/gustaf/create/__init__.py
+++ b/gustaf/create/__init__.py
@@ -1,4 +1,4 @@
-from gustaf.create import vertices
+from gustaf.create import vertices,faces,volumes
 
 try:
     from gustaf.create import spline
@@ -14,5 +14,7 @@ except ImportError:
 
 __all__ = [
         "vertices",
+        "faces",
+        "volumes",
         "spline",
 ]

--- a/gustaf/create/__init__.py
+++ b/gustaf/create/__init__.py
@@ -1,4 +1,4 @@
-from gustaf.create import vertices,faces,volumes
+from gustaf.create import vertices, faces, volumes
 
 try:
     from gustaf.create import spline

--- a/gustaf/create/faces.py
+++ b/gustaf/create/faces.py
@@ -10,9 +10,7 @@ from gustaf import settings
 
 def quad_block_mesh(
         bounds = [[0, 0], [1, 1]],
-        resolutions = [2, 2],
-        create_vertex_groups = True,
-        create_edge_groups = True
+        resolutions = [2, 2]
         ):
     """
     Create structured quadrangle block mesh.
@@ -22,8 +20,6 @@ def quad_block_mesh(
         Minimum and maximum coordinates.
     resolutions: (2) array
         Vertex count in each dimension.
-    create_vertex_groups: bool
-    create_face_groups: bool
     Returns
     --------
     face_mesh: Volumes
@@ -36,24 +32,7 @@ def quad_block_mesh(
             "All resolutions must be at least 2."
 
     vertex_mesh = create.vertices.raster(bounds, resolutions)
+    connectivity = utils.connec.make_quad_faces(resolutions)
+    face_mesh = Faces(vertex_mesh.vertices, connectivity)
 
-    if not create_vertex_groups and not create_face_groups:
-        connectivity = utils.connec.make_quad_faces(
-                resolutions, create_vertex_groups=False)
-        face_mesh = Faces(vertex_mesh.vertices, connectivity)
-    else:
-        connectivity, vertex_groups = utils.connec.make_quad_faces(
-                resolutions, create_vertex_groups=True)
-        face_mesh = Faces(vertex_mesh.vertices, connectivity)
-
-        if create_vertex_groups:
-            for group_name, vertex_ids in vertex_groups.items():
-                face_mesh.vertex_groups[group_name] = vertex_ids
-        if create_edge_groups:
-            edge_connectivity = face_mesh.get_edges()
-            for group_name, vertex_ids in vertex_groups.items():
-                face_mesh.edge_groups[group_name] = (
-                utils.groups.vertex_to_element_group(edge_connectivity,
-                        vertex_ids))
-
-    return 
+    return face_mesh

--- a/gustaf/create/faces.py
+++ b/gustaf/create/faces.py
@@ -6,12 +6,9 @@ import numpy as np
 
 from gustaf.faces import Faces
 from gustaf import utils, create
-from gustaf import settings
 
-def quad_block_mesh(
-        bounds = [[0, 0], [1, 1]],
-        resolutions = [2, 2]
-        ):
+
+def quad_block_mesh(bounds=[[0, 0], [1, 1]], resolutions=[2, 2]):
     """
     Create structured quadrangle block mesh.
     Parameters
@@ -25,11 +22,11 @@ def quad_block_mesh(
     face_mesh: Volumes
     """
     assert np.array(bounds).shape == (2, 2), \
-            "bounds array must have 2x2 entries."
+        "bounds array must have 2x2 entries."
     assert len(resolutions) == 2, \
-            "resolutions array must have two entries."
+        "resolutions array must have two entries."
     assert np.greater(resolutions, 1).all(), \
-            "All resolutions must be at least 2."
+        "All resolutions must be at least 2."
 
     vertex_mesh = create.vertices.raster(bounds, resolutions)
     connectivity = utils.connec.make_quad_faces(resolutions)

--- a/gustaf/create/faces.py
+++ b/gustaf/create/faces.py
@@ -23,7 +23,7 @@ def box(bounds=[[0, 0], [1, 1]], resolutions=[2, 2]):
     """
     if np.array(bounds).shape != (2, 2):
         raise ValueError("Bounds must have a dimension of (2, 2).")
-    if len(resolutions) !=2:
+    if len(resolutions) != 2:
         raise ValueError("Resolutions must have two entries.")
     if not np.greater(resolutions, 1).all():
         raise ValueError("All resolution values must be at least 2.")

--- a/gustaf/create/faces.py
+++ b/gustaf/create/faces.py
@@ -1,0 +1,59 @@
+"""gustaf/create/faces.py
+Routines to create faces.
+"""
+
+import numpy as np
+
+from gustaf.faces import Faces
+from gustaf import utils, create
+from gustaf import settings
+
+def quad_block_mesh(
+        bounds = [[0, 0], [1, 1]],
+        resolutions = [2, 2],
+        create_vertex_groups = True,
+        create_edge_groups = True
+        ):
+    """
+    Create structured quadrangle block mesh.
+    Parameters
+    -----------
+    bounds: (2, 2) array
+        Minimum and maximum coordinates.
+    resolutions: (2) array
+        Vertex count in each dimension.
+    create_vertex_groups: bool
+    create_face_groups: bool
+    Returns
+    --------
+    face_mesh: Volumes
+    """
+    assert np.array(bounds).shape == (2, 2), \
+            "bounds array must have 2x2 entries."
+    assert len(resolutions) == 2, \
+            "resolutions array must have two entries."
+    assert np.greater(resolutions, 1).all(), \
+            "All resolutions must be at least 2."
+
+    vertex_mesh = create.vertices.raster(bounds, resolutions)
+
+    if not create_vertex_groups and not create_face_groups:
+        connectivity = utils.connec.make_quad_faces(
+                resolutions, create_vertex_groups=False)
+        face_mesh = Faces(vertex_mesh.vertices, connectivity)
+    else:
+        connectivity, vertex_groups = utils.connec.make_quad_faces(
+                resolutions, create_vertex_groups=True)
+        face_mesh = Faces(vertex_mesh.vertices, connectivity)
+
+        if create_vertex_groups:
+            for group_name, vertex_ids in vertex_groups.items():
+                face_mesh.vertex_groups[group_name] = vertex_ids
+        if create_edge_groups:
+            edge_connectivity = face_mesh.get_edges()
+            for group_name, vertex_ids in vertex_groups.items():
+                face_mesh.edge_groups[group_name] = (
+                utils.groups.vertex_to_element_group(edge_connectivity,
+                        vertex_ids))
+
+    return 

--- a/gustaf/create/faces.py
+++ b/gustaf/create/faces.py
@@ -22,11 +22,11 @@ def box(bounds=[[0, 0], [1, 1]], resolutions=[2, 2]):
     face_mesh: Volumes
     """
     if np.array(bounds).shape != (2, 2):
-        raise ValueException("Bounds must have a dimension of (2, 2).")
+        raise ValueError("Bounds must have a dimension of (2, 2).")
     if len(resolutions) !=2:
-        raise ValueException("Resolutions must have two entries.")
+        raise ValueError("Resolutions must have two entries.")
     if not np.greater(resolutions, 1).all():
-        raise ValueException("All resolution values must be at least 2.")
+        raise ValueError("All resolution values must be at least 2.")
 
     vertex_mesh = create.vertices.raster(bounds, resolutions)
     connectivity = utils.connec.make_quad_faces(resolutions)

--- a/gustaf/create/faces.py
+++ b/gustaf/create/faces.py
@@ -8,7 +8,7 @@ from gustaf.faces import Faces
 from gustaf import utils, create
 
 
-def quad_block_mesh(bounds=[[0, 0], [1, 1]], resolutions=[2, 2]):
+def box(bounds=[[0, 0], [1, 1]], resolutions=[2, 2]):
     """
     Create structured quadrangle block mesh.
     Parameters
@@ -21,12 +21,12 @@ def quad_block_mesh(bounds=[[0, 0], [1, 1]], resolutions=[2, 2]):
     --------
     face_mesh: Volumes
     """
-    assert np.array(bounds).shape == (2, 2), \
-        "bounds array must have 2x2 entries."
-    assert len(resolutions) == 2, \
-        "resolutions array must have two entries."
-    assert np.greater(resolutions, 1).all(), \
-        "All resolutions must be at least 2."
+    if np.array(bounds).shape != (2, 2):
+        raise ValueException("Bounds must have a dimension of (2, 2).")
+    if len(resolutions) !=2:
+        raise ValueException("Resolutions must have two entries.")
+    if not np.greater(resolutions, 1).all():
+        raise ValueException("All resolution values must be at least 2.")
 
     vertex_mesh = create.vertices.raster(bounds, resolutions)
     connectivity = utils.connec.make_quad_faces(resolutions)

--- a/gustaf/create/volumes.py
+++ b/gustaf/create/volumes.py
@@ -1,0 +1,42 @@
+"""gustaf/create/volumes.py
+Routines to create volumes.
+"""
+
+import numpy as np
+import random
+
+from gustaf.volumes import Volumes
+from gustaf import utils
+from gustaf import create
+
+def hexa_block_mesh(
+        bounds = [[0., 0., 0.], [1., 1., 1.]],
+        resolutions = [2, 2, 2]
+        ):
+    """
+    Create structured hexahedron block mesh.
+    Parameters
+    -----------
+    bounds: (2, 3) array
+        Minimum and maximum coordinates.
+    resolutions: (3) array
+        Vertex count in each dimension.
+    create_vertex_groups: bool
+    create_face_groups: bool
+    Returns
+    --------
+    volume_mesh: Volumes
+    """
+    assert np.array(bounds).shape == (2, 3), \
+            "bounds array must have 2x3 entries."
+    assert len(resolutions) == 3, \
+            "resolutions array must have three entries."
+    assert np.greater(resolutions, 1).all(), \
+            "All resolutions must be at least 2."
+
+    vertex_mesh = create.vertices.raster(bounds, resolutions)
+
+    connectivity = utils.connec.make_hexa_volumes(resolutions)
+    volume_mesh = Volumes(vertex_mesh.vertices, connectivity)
+
+    return volume_mesh

--- a/gustaf/create/volumes.py
+++ b/gustaf/create/volumes.py
@@ -24,11 +24,11 @@ def box(bounds = [[0., 0., 0.], [1., 1., 1.]],
     volume_mesh: Volumes
     """
     if np.array(bounds).shape != (2, 3):
-        raise ValueException("Bounds must have a dimension of (2, 3).")
+        raise ValueError("Bounds must have a dimension of (2, 3).")
     if len(resolutions) !=3:
-        raise ValueException("Resolutions must have three entries.")
+        raise ValueError("Resolutions must have three entries.")
     if not np.greater(resolutions, 1).all():
-        raise ValueException("All resolution values must be at least 2.")
+        raise ValueError("All resolution values must be at least 2.")
 
     vertex_mesh = create.vertices.raster(bounds, resolutions)
 

--- a/gustaf/create/volumes.py
+++ b/gustaf/create/volumes.py
@@ -8,9 +8,8 @@ from gustaf.volumes import Volumes
 from gustaf import utils
 from gustaf import create
 
-def box(bounds = [[0., 0., 0.], [1., 1., 1.]],
-        resolutions = [2, 2, 2]
-        ):
+
+def box(bounds=[[0., 0., 0.], [1., 1., 1.]], resolutions=[2, 2, 2]):
     """
     Create structured hexahedron block mesh.
     Parameters
@@ -25,7 +24,7 @@ def box(bounds = [[0., 0., 0.], [1., 1., 1.]],
     """
     if np.array(bounds).shape != (2, 3):
         raise ValueError("Bounds must have a dimension of (2, 3).")
-    if len(resolutions) !=3:
+    if len(resolutions) != 3:
         raise ValueError("Resolutions must have three entries.")
     if not np.greater(resolutions, 1).all():
         raise ValueError("All resolution values must be at least 2.")

--- a/gustaf/create/volumes.py
+++ b/gustaf/create/volumes.py
@@ -3,16 +3,15 @@ Routines to create volumes.
 """
 
 import numpy as np
-import random
 
 from gustaf.volumes import Volumes
 from gustaf import utils
 from gustaf import create
 
+
 def hexa_block_mesh(
-        bounds = [[0., 0., 0.], [1., 1., 1.]],
-        resolutions = [2, 2, 2]
-        ):
+        bounds=[[0., 0., 0.], [1., 1., 1.]], resolutions=[2, 2, 2]
+):
     """
     Create structured hexahedron block mesh.
     Parameters
@@ -28,11 +27,11 @@ def hexa_block_mesh(
     volume_mesh: Volumes
     """
     assert np.array(bounds).shape == (2, 3), \
-            "bounds array must have 2x3 entries."
+        "bounds array must have 2x3 entries."
     assert len(resolutions) == 3, \
-            "resolutions array must have three entries."
+        "resolutions array must have three entries."
     assert np.greater(resolutions, 1).all(), \
-            "All resolutions must be at least 2."
+        "All resolutions must be at least 2."
 
     vertex_mesh = create.vertices.raster(bounds, resolutions)
 

--- a/gustaf/create/volumes.py
+++ b/gustaf/create/volumes.py
@@ -8,10 +8,9 @@ from gustaf.volumes import Volumes
 from gustaf import utils
 from gustaf import create
 
-
-def hexa_block_mesh(
-        bounds=[[0., 0., 0.], [1., 1., 1.]], resolutions=[2, 2, 2]
-):
+def box(bounds = [[0., 0., 0.], [1., 1., 1.]],
+        resolutions = [2, 2, 2]
+        ):
     """
     Create structured hexahedron block mesh.
     Parameters
@@ -20,18 +19,16 @@ def hexa_block_mesh(
         Minimum and maximum coordinates.
     resolutions: (3) array
         Vertex count in each dimension.
-    create_vertex_groups: bool
-    create_face_groups: bool
     Returns
     --------
     volume_mesh: Volumes
     """
-    assert np.array(bounds).shape == (2, 3), \
-        "bounds array must have 2x3 entries."
-    assert len(resolutions) == 3, \
-        "resolutions array must have three entries."
-    assert np.greater(resolutions, 1).all(), \
-        "All resolutions must be at least 2."
+    if np.array(bounds).shape != (2, 3):
+        raise ValueException("Bounds must have a dimension of (2, 3).")
+    if len(resolutions) !=3:
+        raise ValueException("Resolutions must have three entries.")
+    if not np.greater(resolutions, 1).all():
+        raise ValueException("All resolution values must be at least 2.")
 
     vertex_mesh = create.vertices.raster(bounds, resolutions)
 


### PR DESCRIPTION
## Related issues
from PR #20.

## Description
This PR extends ```gustaf.create``` by  ```faces```  and ```volumes```. Simple routines to create a 2D-structured quadrangle block mesh mesh and a 3D-structured hexahedron block mesh. Functions are:

```
    faces.quad_block_mesh(bounds,resolutions)
    volumes.hexa_block_mesh(bounds, resolutions)
```
A small example ```create_block_mesh.py``` is provided.