### PR TITLE
Update workflows and add CD for PyPi

### DIFF
--- a/.github/workflows/build_and_upload_wheels.yml
+++ b/.github/workflows/build_and_upload_wheels.yml
@@ -1,0 +1,36 @@
+name: build full and pypi upload
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  wheel_build_full:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: build wheels
+        uses: pypa/cibuildwheel@v2.11.1
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  upload_pypi:
+    needs: [wheel_build_full]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.6.1
+        with:
+          skip_existing: true
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: build docs
 on:
   push:
-    branches: ["main", "docs"]
+    branches: ["main"]
 
 jobs:
   docs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,9 @@ jobs:
         message: formatting suggestions
  
     - name: install gustaf
-      run: python3 setup.py install
+      run: |
+        python3 -m pip install numpy
+        python3 setup.py install
 
     - name: prepare test and test
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,6 @@ name: format check and runs tests
 on:
   pull_request:
     branches: ["main"]
-  push:
-    branches: ["main"]
 
 jobs:
   build_and_tests:
@@ -12,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11" ]
         os: [ubuntu-latest, macos-latest]
 
     steps:


### PR DESCRIPTION
Update the CI and add CD.
There are four workflows for the repository
	- `build_and_upload_wheels`.yml -> every push to main
	- `docs`.yml -> push to `main`
	- `doc_tes`.yml -> every push
	- `tests`.yml -> every pull request to `main`

The workflow `build_and_upload_wheels` creates wheels for macOS and ubuntu and upload it to [PyPI](https://pypi.org/search/?q=tataratat). 
The workflow `tests` build the repository, checks the format and run tests with pytest. 
The other workflows are for creating and testing the doc files.  