### PR TITLE
fix showing after shrink()

### DIFF
--- a/gustaf/edges.py
+++ b/gustaf/edges.py
@@ -450,7 +450,9 @@ class Edges(Vertices):
                 s_elements.vertexdata[key] = value[elements_flat]
 
             # probably wanna take visulation options too
-            s_elements._show_options = deepcopy(self.show_options)
+            s_elements._show_options._options = deepcopy(
+                self.show_options._options
+            )
 
         return s_elements
 


### PR DESCRIPTION
# Overview
after shrink, it was supposed to only copy options, but was copying helpee as well. Now only copies options.