### PR TITLE
Ft tictoc

### DIFF
--- a/gustaf/helpers/data.py
+++ b/gustaf/helpers/data.py
@@ -190,10 +190,6 @@ class DataHolder(GustafBase):
     def __init__(self, helpee):
         """Base class for any data holder. Behaves similar to dict.
 
-        Attributes
-        -----------
-        None
-
         Parameters
         -----------
         helpee: object
@@ -209,10 +205,6 @@ class DataHolder(GustafBase):
         -----------
         key: str
         value: object
-
-        Returns
-        --------
-        None
         """
         raise NotImplementedError(
             "Sorry, you can't set items directly for "
@@ -254,14 +246,6 @@ class DataHolder(GustafBase):
     def clear(self):
         """
         Clears saved data by reassigning new dict
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        None
         """
         self._saved = dict()
 
@@ -287,10 +271,6 @@ class DataHolder(GustafBase):
     def keys(self):
         """Returns keys of data holding dict.
 
-        Parameters
-        -----------
-        None
-
         Returns
         --------
         keys: dict_keys
@@ -300,10 +280,6 @@ class DataHolder(GustafBase):
     def values(self):
         """Returns values of data holding dict.
 
-        Parameters
-        -----------
-        None
-
         Returns
         --------
         values: dict_values
@@ -312,10 +288,6 @@ class DataHolder(GustafBase):
 
     def items(self):
         """Returns items of data holding dict.
-
-        Parameters
-        -----------
-        None
 
         Returns
         --------
@@ -331,12 +303,10 @@ class ComputedData(DataHolder):
     __slots__ = ()
 
     def __init__(self, helpee, **kwargs):
-        """Stores last computed values. Keys are expected to be the same as
-        helpee's function that computes the value.
+        """Stores last computed values.
 
-        Attributes
-        -----------
-        None
+        Keys are expected to be the same as helpee's function that computes the
+         value.
 
         Parameters
         -----------
@@ -451,17 +421,12 @@ class VertexData(DataHolder):
     __slots__ = ()
 
     def __init__(self, helpee):
-        """
-        Checks if helpee has vertices as attr beforehand.
+        """Checks if helpee has vertices as attr beforehand.
 
         Parameters
         ----------
         helpee: Vertices
           Vertices and its derived classes.
-
-        Returns
-        -------
-        None
         """
         if not hasattr(helpee, "vertices"):
             raise AttributeError("Helpee does not have `vertices`.")
@@ -469,8 +434,8 @@ class VertexData(DataHolder):
         super().__init__(helpee)
 
     def _validate_len(self, value=None, raise_=True):
-        """
-        Checks if given value is a valid vertexdata based of its length.
+        """Checks if given value is a valid vertexdata based of its length.
+
         If raise_, throws error, else, deletes all incompatible values.
         Only checks len(). If array has (1, len) shape, this will still return
         False.
@@ -525,7 +490,7 @@ class VertexData(DataHolder):
 
     def __setitem__(self, key, value):
         """
-        Performs len() based check before stroing vertexdata.
+        Performs len() based check before storing vertexdata.
 
         Parameters
         ----------
@@ -706,10 +671,10 @@ class SplineDataAdaptor(GustafBase):
                         "Data cannot be represented at specified locations."
                         "Requires one of the following requirements: "
                         "1) is a spline derived from splinepy's spline; "
-                        "2) data has `data.evalauate()`; "
+                        "2) data has `data.evaluate()`; "
                         "3) length of the data and location should match."
                     )
-            # location is sepcified, meaning we don't need sample()
+            # location is specified, meaning we don't need sample()
             return None
 
         # can call sample or has a function?

--- a/gustaf/utils/__init__.py
+++ b/gustaf/utils/__init__.py
@@ -1,4 +1,5 @@
 from gustaf.utils import arr, connec, log, tictoc
+from gustaf.utils.tictoc import Tic
 
 # Alias
 connectivity = connec
@@ -9,4 +10,5 @@ __all__ = [
     "connectivity",
     "log",
     "tictoc",
+    "Tic",
 ]

--- a/gustaf/utils/tictoc.py
+++ b/gustaf/utils/tictoc.py
@@ -24,9 +24,9 @@ class Tic(GustafBase):
         Parameters
         ----------
         title: str
-          title for this measurement.
+          Title for this measurement. Defaults to "untitled".
         log_level: str
-          Valid options are {"info", "debug", "warning"}
+          Valid options are {"info", "debug", "warning"}. Defaults to "debug".
         """
         # select logger based on logger level
         self._logger = eval(f"self._log{str(log_level).lower()[0]}")
@@ -47,10 +47,10 @@ class Tic(GustafBase):
         Parameters
         ----------
         name: str
-          name of this specific measurement.
-          By default it assign a number to this lap.
+          Name of this specific measurement lap.
+          By default, it assigns a number to this lap.
         log: bool
-          If True, will log lapsed time.
+          If True, will log lapsed time. Defaults to None.
 
         Returns
         -------
@@ -64,22 +64,22 @@ class Tic(GustafBase):
         )
 
         if log:
-            self._logger("time lapsed: ", self._laps[-2] - self._laps[-1])
+            self._logger(f"{self._title} - Lap {name}:  {self._laps[-2] - self._laps[-1]}")
 
     def summary(self, print_=False):
         """
-        Prints measurement summany.
+        Prints measurement summary to the log.
 
         Parameters
         ----------
-        print_: bool
+        print_: Print the summary also to stdout. Defaults to False.
 
 
         Returns
         -------
         records: tuple
-          Records starting from starting point. tuple of names and cummulative
-          lapsed time.
+          Lap timings in a tuple consisting of a list of the lap names and
+           times for each lap from the timer start (cumulative time).
         """
         message = [f"\n+++ {self._title} - time logs +++\n"]
 
@@ -87,8 +87,7 @@ class Tic(GustafBase):
 
         # extract info
         start = self._laps[0]
-        cummulative_raw = [lap - start for lap in self._laps[1:]]
-        cummulative = [f"{c:.10f}" for c in cummulative_raw]
+        cummulative = [f"{lap-start:.10f}" for lap in self._laps[1:]]
         diff = [
             f"{l1 - l0:.10f}"
             for l0, l1 in zip(self._laps[:-1], self._laps[1:])

--- a/gustaf/utils/tictoc.py
+++ b/gustaf/utils/tictoc.py
@@ -2,3 +2,101 @@
 
 Timer that tics, tocs and logs.
 """
+from time import perf_counter as now
+
+from gustaf._base import GustafBase
+
+
+class Tic(GustafBase):
+    """
+    Timer class for easier time measurement.
+    """
+
+    __slots__ = ("_title", "_names", "_laps", "_logger")
+
+    # add short cut to perf_counter in case you just want pure "now"
+    now = now
+
+    def __init__(self, title="untitled", log_level="debug"):
+        """
+        Configures the timer and logger. Marks the starting point.
+        """
+        # select logger based on logger level
+        self._logger = eval(f"self._log{str(log_level).lower()[0]}")
+
+        # initialize names
+        self._names = []
+
+        # give name
+        self._title = str(title)
+
+        # start
+        self._laps = [now()]
+
+    def toc(self, name=None, log=True):
+        """
+        Adds now to the measurements.
+
+        Returns
+        -------
+        None
+        """
+        # measure now
+        self._laps.append(now())
+
+        self._names.append(
+            f"lap-{len(self._laps) - 2}" if name is None else str(name)
+        )
+
+        if log:
+            self._logger("time lapsed: ", self._laps[-2] - self._laps[-1])
+
+    def summary(self, print_=False):
+        """
+        Prints measurement summany.
+
+        Parameters
+        ----------
+        print_: bool
+
+
+        Returns
+        -------
+        records: tuple
+          Records starting from starting point. tuple of names and cummulative
+          lapsed time.
+        """
+        message = [f"\n+++ {self._title} - time logs +++\n"]
+
+        name_width = int(max([len(n) for n in self._names]))
+
+        # extract info
+        start = self._laps[0]
+        cummulative_raw = [lap - start for lap in self._laps[1:]]
+        cummulative = [f"{c:.10f}" for c in cummulative_raw]
+        diff = [
+            f"{l1 - l0:.10f}"
+            for l0, l1 in zip(self._laps[:-1], self._laps[1:])
+        ]
+        diff_width = int(max([len(d) for d in diff]))
+        cumm_width = int(max([len(c) for c in cummulative]))
+
+        message.append(
+            f"{'names'.ljust(name_width)} | "
+            f"{'diff'.rjust(diff_width)} | "
+            f"{'cummulative'.rjust(cumm_width)}\n"
+        )
+
+        for n, d, c in zip(self._names, diff, cummulative):
+            this_line = (
+                f"{n.ljust(name_width)} | "
+                f"{d.rjust(diff_width)} | "
+                f"{c.rjust(cumm_width)}\n"
+            )
+            message.append(this_line)
+
+        self._logger(*message)
+        if print_:
+            print(*message)
+
+        return self._names.copy(), cummulative

--- a/gustaf/utils/tictoc.py
+++ b/gustaf/utils/tictoc.py
@@ -64,7 +64,9 @@ class Tic(GustafBase):
         )
 
         if log:
-            self._logger(f"{self._title} - Lap {name}:  {self._laps[-2] - self._laps[-1]}")
+            self._logger(
+                f"{self._title} - Lap {name}:  {self._laps[-2] - self._laps[-1]}"
+            )
 
     def summary(self, print_=False):
         """

--- a/gustaf/utils/tictoc.py
+++ b/gustaf/utils/tictoc.py
@@ -20,6 +20,13 @@ class Tic(GustafBase):
     def __init__(self, title="untitled", log_level="debug"):
         """
         Configures the timer and logger. Marks the starting point.
+
+        Parameters
+        ----------
+        title: str
+          title for this measurement.
+        log_level: str
+          Valid options are {"info", "debug", "warning"}
         """
         # select logger based on logger level
         self._logger = eval(f"self._log{str(log_level).lower()[0]}")
@@ -33,9 +40,17 @@ class Tic(GustafBase):
         # start
         self._laps = [now()]
 
-    def toc(self, name=None, log=True):
+    def toc(self, name=None, log=False):
         """
         Adds now to the measurements.
+
+        Parameters
+        ----------
+        name: str
+          name of this specific measurement.
+          By default it assign a number to this lap.
+        log: bool
+          If True, will log lapsed time.
 
         Returns
         -------

--- a/gustaf/utils/tictoc.py
+++ b/gustaf/utils/tictoc.py
@@ -65,16 +65,19 @@ class Tic(GustafBase):
 
         if log:
             self._logger(
-                f"{self._title} - Lap {name}:  {self._laps[-2] - self._laps[-1]}"
+                f"{self._title} - {name}:  {self._laps[-2] - self._laps[-1]}"
             )
 
-    def summary(self, print_=False):
+    def summary(self, log=True, print_=False):
         """
         Prints measurement summary to the log.
 
         Parameters
         ----------
-        print_: Print the summary also to stdout. Defaults to False.
+        log: bool
+          Logs the summary. Default is True.
+        print_: bool
+          Prints the summary. Default is False.
 
 
         Returns
@@ -83,36 +86,39 @@ class Tic(GustafBase):
           Lap timings in a tuple consisting of a list of the lap names and
            times for each lap from the timer start (cumulative time).
         """
-        message = [f"\n+++ {self._title} - time logs +++\n"]
-
-        name_width = int(max([len(n) for n in self._names]))
-
-        # extract info
         start = self._laps[0]
         cummulative = [f"{lap-start:.10f}" for lap in self._laps[1:]]
-        diff = [
-            f"{l1 - l0:.10f}"
-            for l0, l1 in zip(self._laps[:-1], self._laps[1:])
-        ]
-        diff_width = int(max([len(d) for d in diff]))
-        cumm_width = int(max([len(c) for c in cummulative]))
 
-        message.append(
-            f"{'names'.ljust(name_width)} | "
-            f"{'diff'.rjust(diff_width)} | "
-            f"{'cummulative'.rjust(cumm_width)}\n"
-        )
+        if log or print_:
+            message = [f"\n+++ {self._title} - time logs +++\n"]
 
-        for n, d, c in zip(self._names, diff, cummulative):
-            this_line = (
-                f"{n.ljust(name_width)} | "
-                f"{d.rjust(diff_width)} | "
-                f"{c.rjust(cumm_width)}\n"
+            name_width = int(max([len(n) for n in self._names]))
+
+            # extract info
+            diff = [
+                f"{l1 - l0:.10f}"
+                for l0, l1 in zip(self._laps[:-1], self._laps[1:])
+            ]
+            diff_width = int(max([len(d) for d in diff]))
+            cumm_width = int(max([len(c) for c in cummulative]))
+
+            message.append(
+                f"{'names'.ljust(name_width)} | "
+                f"{'diff'.rjust(diff_width)} | "
+                f"{'cummulative'.rjust(cumm_width)}\n"
             )
-            message.append(this_line)
 
-        self._logger(*message)
-        if print_:
-            print(*message)
+            for n, d, c in zip(self._names, diff, cummulative):
+                this_line = (
+                    f"{n.ljust(name_width)} | "
+                    f"{d.rjust(diff_width)} | "
+                    f"{c.rjust(cumm_width)}\n"
+                )
+                message.append(this_line)
+
+            if log:
+                self._logger(*message)
+            if print_:
+                print(*message)
 
         return self._names.copy(), cummulative


### PR DESCRIPTION
adds Timer for easy time measurements
cherry-picked @clemens-fricke's docstring clean up

# Example use
```python
import gustaf as gus

# counting starts now!
tic = gus.utils.Tic(
    title="example Tic.toc() use",
    log_level="info" # debug is default
)

add = 1 + 2 + 3
tic.toc("addition")

mul = 1 * 2 * 3
tic.toc("multiplication")

div = 1 / 2 / 3
tic.toc("division")


# log and print summary
tic.summary(print_=True)
```
this will output
```
+++ example Tic.toc() use - time logs +++
 names          |         diff |  cummulative
 addition       | 0.0000010000 | 0.0000010000
 multiplication | 0.0000132080 | 0.0000142080
 division       | 0.0000032500 | 0.0000174580
```