### PR TITLE
Fix spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ assert np.allclose(
 
 # let's visualize some scalar data and vector data defined on vertices
 tet.vertexdata["arange"] = np.arange(len(tet.vertices))  # scalar
-tet.show_options["dataname"] = "arange"
+tet.show_options["data_name"] = "arange"
 tet.vertexdata["random"] = np.random.random((len(tet.vertices), 3))  # vector
 tet.show_options["arrowdata"] = "random"
 tet.show()
@@ -152,7 +152,7 @@ parametric_view = nurbs.create.parametric_view()
 # for more options, checkout `gus.spline.SplineDataAdaptor`
 # following will plot the norm of nurbs' physical coordinates
 nurbs.splinedata["coords"] = nurbs
-nurbs.show_options["dataname"] = "coords"
+nurbs.show_options["data_name"] = "coords"
 
 # show them all together. each arg is plotted on a separate subplot
 # translate tet a bit to avoid overlapping

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ assert np.allclose(
 tet.vertexdata["arange"] = np.arange(len(tet.vertices))  # scalar
 tet.show_options["data_name"] = "arange"
 tet.vertexdata["random"] = np.random.random((len(tet.vertices), 3))  # vector
-tet.show_options["arrowdata"] = "random"
+tet.show_options["arrow_data"] = "random"
 tet.show()
 
 

--- a/README.md
+++ b/README.md
@@ -148,10 +148,10 @@ extruded = nurbs.create.extruded(extrusion_vector=[0, 0, 1])
 revolved = nurbs.create.revolved(axis=[1, 0, 0], angle=70)
 parametric_view = nurbs.create.parametric_view()
 
-# just like vertexdata, you can define splinedata
+# just like vertexdata, you can define spline_data
 # for more options, checkout `gus.spline.SplineDataAdaptor`
 # following will plot the norm of nurbs' physical coordinates
-nurbs.splinedata["coords"] = nurbs
+nurbs.spline_data["coords"] = nurbs
 nurbs.show_options["data_name"] = "coords"
 
 # show them all together. each arg is plotted on a separate subplot

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ tet.show()
 
 # elements can transform to their subelement types
 # set unique=True, if you don't want duplicating internal subelements
-as_faces = tet.tofaces(unique=False)
-as_edges = tet.toedges(unique=False)
+as_faces = tet.to_faces(unique=False)
+as_edges = tet.to_edges(unique=False)
 
 # as geometry classes inherit from its subelement class, we can
 # extract subelement connectivity directly.

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ assert np.allclose(
 )
 
 # let's visualize some scalar data and vector data defined on vertices
-tet.vertexdata["arange"] = np.arange(len(tet.vertices))  # scalar
+tet.vertex_data["arange"] = np.arange(len(tet.vertices))  # scalar
 tet.show_options["data_name"] = "arange"
-tet.vertexdata["random"] = np.random.random((len(tet.vertices), 3))  # vector
+tet.vertex_data["random"] = np.random.random((len(tet.vertices), 3))  # vector
 tet.show_options["arrow_data"] = "random"
 tet.show()
 
@@ -148,7 +148,7 @@ extruded = nurbs.create.extruded(extrusion_vector=[0, 0, 1])
 revolved = nurbs.create.revolved(axis=[1, 0, 0], angle=70)
 parametric_view = nurbs.create.parametric_view()
 
-# just like vertexdata, you can define spline_data
+# just like vertex_data, you can define spline_data
 # for more options, checkout `gus.spline.SplineDataAdaptor`
 # following will plot the norm of nurbs' physical coordinates
 nurbs.spline_data["coords"] = nurbs

--- a/examples/show_splinedata.py
+++ b/examples/show_splinedata.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     b = bspline2p3d()
     b.splinedata["me"] = b
     b.show_options["data_name"] = "me"
-    b.show_options["arrowdata"] = "me"
+    b.show_options["arrow_data"] = "me"
     gus.show(
         ["2. Show coordinate norm as scalar field and coordinate as arrows", b]
     )
@@ -72,8 +72,8 @@ if __name__ == "__main__":
     b = bspline2p3d()
     b.splinedata["me"] = b
     b.show_options["data_name"] = "me"
-    b.show_options["arrowdata"] = "me"
-    b.show_options["arrowdata_on"] = np.random.random((100, 2))  # para_coords
+    b.show_options["arrow_data"] = "me"
+    b.show_options["arrow_data_on"] = np.random.random((100, 2))  # para_coords
     gus.show(
         ["3. Show coordinates norm and as arrows on 100 random points.", b]
     )
@@ -82,8 +82,8 @@ if __name__ == "__main__":
     b = bspline2p3d()
     b.splinedata["me"] = b
     b.show_options["data_name"] = "me"
-    b.show_options["arrowdata"] = "me"
-    b.show_options["arrowdata_on"] = np.random.random((100, 2))  # para_coords
+    b.show_options["arrow_data"] = "me"
+    b.show_options["arrow_data_on"] = np.random.random((100, 2))  # para_coords
     b.show_options["scalarbar"] = True
     gus.show(
         ["4. Show 3. and 3. in parametric space view with scalarbar.", b],
@@ -109,7 +109,7 @@ if __name__ == "__main__":
     # the rest is the same
     b = bspline2p3d()
     b.splinedata["der01"] = plot_func_data
-    b.show_options["arrowdata"] = "der01"
+    b.show_options["arrow_data"] = "der01"
     gus.show(
         [
             "5. Show partial derivative of seconda parametric dimension.\n"
@@ -123,9 +123,9 @@ if __name__ == "__main__":
     # however, gold
     b = bspline2p3d()
     b.splinedata["der01"] = plot_func_data
-    b.show_options["arrowdata"] = "der01"
-    b.show_options["arrowdata_on"] = np.random.random((100, 2))  # para_coords
-    b.show_options["arrowdata_color"] = "gold"
+    b.show_options["arrow_data"] = "der01"
+    b.show_options["arrow_data_on"] = np.random.random((100, 2))  # para_coords
+    b.show_options["arrow_data_color"] = "gold"
     gus.show(
         [
             "5.1. Same data as 5. However, on 100 random places with gold "
@@ -140,7 +140,7 @@ if __name__ == "__main__":
     fixed_data = gus.spline.SplineDataAdaptor(values, locations=locations)
     b = bspline2p3d()
     b.splinedata["fixed"] = fixed_data
-    b.show_options["arrowdata"] = "fixed"
+    b.show_options["arrow_data"] = "fixed"
     gus.show(
         [
             "6. Show arbitrary array data on predefined locations using "
@@ -151,7 +151,7 @@ if __name__ == "__main__":
 
     # fixed location data can't be shown in other requested locations.
     # followings won't work
-    # b.show_options["arrowdata_on"] = locations[:5]
+    # b.show_options["arrow_data_on"] = locations[:5]
     # b.show()
 
     # 7. plot any data with a function
@@ -181,14 +181,14 @@ if __name__ == "__main__":
         function=func,
     )
     b.splinedata["deformed"] = deformed_data
-    b.show_options["arrowdata"] = "deformed"
+    b.show_options["arrow_data"] = "deformed"
     # arrows are always automatically scaled. for this one, let's not
-    b.show_options["arrowdata_scale"] = 1
-    b.show_options["arrowdata_on"] = locations
+    b.show_options["arrow_data_scale"] = 1
+    b.show_options["arrow_data_on"] = locations
     # let's see in parametric space
     p_view = b.create.parametric_view()  # shallow copies data and options
-    p_view.show_options.pop("arrowdata_scale")  # we want automatic scaling
-    p_view.show_options["arrowdata_color"] = "gold"
+    p_view.show_options.pop("arrow_data_scale")  # we want automatic scaling
+    p_view.show_options["arrow_data_color"] = "gold"
     p_view.show_options["data_name"] = "deformed"
     # plot side by side
     gus.show(
@@ -257,8 +257,8 @@ if __name__ == "__main__":
     disc = gus.spline.create.disk(2, angle=123)
     disc.normalize_knot_vectors()
     disc.splinedata["nice"] = nice_data
-    disc.show_options["arrowdata"] = "nice"
-    disc.show_options["arrowdata_color"] = "jet"
+    disc.show_options["arrow_data"] = "nice"
+    disc.show_options["arrow_data_color"] = "jet"
     gus.show(
         [
             "8. Showing arbitrary data with callback.\n"

--- a/examples/show_splinedata.py
+++ b/examples/show_splinedata.py
@@ -45,23 +45,23 @@ if __name__ == "__main__":
     # turn on debug logs
     # gus.utils.log.configure(debug=True)
 
-    # define splinedata
+    # define spline_data
     # 1. see coordinates's norm
     b = bspline2p3d()
-    b.splinedata["me"] = b
+    b.spline_data["me"] = b
     b.show_options["data_name"] = "me"
     gus.show(["1. Show norm of coordinates.", b])
 
     # 1.1 default scalarbar
     b = bspline2p3d()
-    b.splinedata["me"] = b
+    b.spline_data["me"] = b
     b.show_options["data_name"] = "me"
     b.show_options["scalarbar"] = True
     gus.show(["1.1. Show 1. plus scalarbar", b])
 
     # 2. see coordinate's norm and as arrow
     b = bspline2p3d()
-    b.splinedata["me"] = b
+    b.spline_data["me"] = b
     b.show_options["data_name"] = "me"
     b.show_options["arrow_data"] = "me"
     gus.show(
@@ -70,7 +70,7 @@ if __name__ == "__main__":
 
     # 3. see coordinates norm and as arrows only on specified places
     b = bspline2p3d()
-    b.splinedata["me"] = b
+    b.spline_data["me"] = b
     b.show_options["data_name"] = "me"
     b.show_options["arrow_data"] = "me"
     b.show_options["arrow_data_on"] = np.random.random((100, 2))  # para_coords
@@ -80,7 +80,7 @@ if __name__ == "__main__":
 
     # 4. see 3. with parametric_view
     b = bspline2p3d()
-    b.splinedata["me"] = b
+    b.spline_data["me"] = b
     b.show_options["data_name"] = "me"
     b.show_options["arrow_data"] = "me"
     b.show_options["arrow_data_on"] = np.random.random((100, 2))  # para_coords
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     plot_func_data = gus.spline.SplineDataAdaptor(b, function=plot_func)
     # the rest is the same
     b = bspline2p3d()
-    b.splinedata["der01"] = plot_func_data
+    b.spline_data["der01"] = plot_func_data
     b.show_options["arrow_data"] = "der01"
     gus.show(
         [
@@ -122,7 +122,7 @@ if __name__ == "__main__":
     # remove on to sample same way as spline.
     # however, gold
     b = bspline2p3d()
-    b.splinedata["der01"] = plot_func_data
+    b.spline_data["der01"] = plot_func_data
     b.show_options["arrow_data"] = "der01"
     b.show_options["arrow_data_on"] = np.random.random((100, 2))  # para_coords
     b.show_options["arrow_data_color"] = "gold"
@@ -139,7 +139,7 @@ if __name__ == "__main__":
     values = np.repeat(np.linspace(1, 2, 15), 3).reshape(-1, 3) + [0, 0, 2]
     fixed_data = gus.spline.SplineDataAdaptor(values, locations=locations)
     b = bspline2p3d()
-    b.splinedata["fixed"] = fixed_data
+    b.spline_data["fixed"] = fixed_data
     b.show_options["arrow_data"] = "fixed"
     gus.show(
         [
@@ -180,7 +180,7 @@ if __name__ == "__main__":
         data=(b, deformed),
         function=func,
     )
-    b.splinedata["deformed"] = deformed_data
+    b.spline_data["deformed"] = deformed_data
     b.show_options["arrow_data"] = "deformed"
     # arrows are always automatically scaled. for this one, let's not
     b.show_options["arrow_data_scale"] = 1
@@ -256,7 +256,7 @@ if __name__ == "__main__":
     )
     disc = gus.spline.create.disk(2, angle=123)
     disc.normalize_knot_vectors()
-    disc.splinedata["nice"] = nice_data
+    disc.spline_data["nice"] = nice_data
     disc.show_options["arrow_data"] = "nice"
     disc.show_options["arrow_data_color"] = "jet"
     gus.show(

--- a/examples/show_splinedata.py
+++ b/examples/show_splinedata.py
@@ -49,20 +49,20 @@ if __name__ == "__main__":
     # 1. see coordinates's norm
     b = bspline2p3d()
     b.splinedata["me"] = b
-    b.show_options["dataname"] = "me"
+    b.show_options["data_name"] = "me"
     gus.show(["1. Show norm of coordinates.", b])
 
     # 1.1 default scalarbar
     b = bspline2p3d()
     b.splinedata["me"] = b
-    b.show_options["dataname"] = "me"
+    b.show_options["data_name"] = "me"
     b.show_options["scalarbar"] = True
     gus.show(["1.1. Show 1. plus scalarbar", b])
 
     # 2. see coordinate's norm and as arrow
     b = bspline2p3d()
     b.splinedata["me"] = b
-    b.show_options["dataname"] = "me"
+    b.show_options["data_name"] = "me"
     b.show_options["arrowdata"] = "me"
     gus.show(
         ["2. Show coordinate norm as scalar field and coordinate as arrows", b]
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     # 3. see coordinates norm and as arrows only on specified places
     b = bspline2p3d()
     b.splinedata["me"] = b
-    b.show_options["dataname"] = "me"
+    b.show_options["data_name"] = "me"
     b.show_options["arrowdata"] = "me"
     b.show_options["arrowdata_on"] = np.random.random((100, 2))  # para_coords
     gus.show(
@@ -81,7 +81,7 @@ if __name__ == "__main__":
     # 4. see 3. with parametric_view
     b = bspline2p3d()
     b.splinedata["me"] = b
-    b.show_options["dataname"] = "me"
+    b.show_options["data_name"] = "me"
     b.show_options["arrowdata"] = "me"
     b.show_options["arrowdata_on"] = np.random.random((100, 2))  # para_coords
     b.show_options["scalarbar"] = True
@@ -189,7 +189,7 @@ if __name__ == "__main__":
     p_view = b.create.parametric_view()  # shallow copies data and options
     p_view.show_options.pop("arrowdata_scale")  # we want automatic scaling
     p_view.show_options["arrowdata_color"] = "gold"
-    p_view.show_options["dataname"] = "deformed"
+    p_view.show_options["data_name"] = "deformed"
     # plot side by side
     gus.show(
         [

--- a/examples/show_volumes.py
+++ b/examples/show_volumes.py
@@ -49,9 +49,9 @@ if __name__ == "__main__":
     tet.show_options["c"] = "green"
     tet.show()
 
-    # display vertexdata
-    # assign values to vertexdata
-    hexa.vertexdata["arange"] = np.arange(len(v))
-    # set vertexdata to plot
+    # display vertex_data
+    # assign values to vertex_data
+    hexa.vertex_data["arange"] = np.arange(len(v))
+    # set vertex_data to plot
     hexa.show_options["data_name"] = "arange"
     hexa.show()

--- a/examples/show_volumes.py
+++ b/examples/show_volumes.py
@@ -53,5 +53,5 @@ if __name__ == "__main__":
     # assign values to vertexdata
     hexa.vertexdata["arange"] = np.arange(len(v))
     # set vertexdata to plot
-    hexa.show_options["dataname"] = "arange"
+    hexa.show_options["data_name"] = "arange"
     hexa.show()

--- a/examples/shrink_elements.py
+++ b/examples/shrink_elements.py
@@ -10,10 +10,10 @@ if __name__ == "__main__":
     v = gus.Volumes(vertices.vertices, connec)
 
     # v shrink - f shrink - e shrink
-    e = v.shrink().tofaces().shrink().toedges().shrink()
+    e = v.shrink().to_faces().shrink().to_edges().shrink()
     e.show_options["as_arrows"] = True
 
-    direct_toedges = v.toedges(unique=False).shrink()
+    direct_toedges = v.to_edges(unique=False).shrink()
     direct_toedges.show_options["as_arrows"] = True
 
     # not the most efficient way, but it is possible.
@@ -21,19 +21,19 @@ if __name__ == "__main__":
         ["v, Volumes", v],
         ["v.shrink()", v.shrink()],
         [
-            "v.shrink().tofaces().shrink()",
-            v.shrink().tofaces().shrink(),
+            "v.shrink().to_faces().shrink()",
+            v.shrink().to_faces().shrink(),
         ],
         [
-            "v.shrink().tofaces().shrink().toedges().shrink()",
-            v.shrink().tofaces().shrink().toedges().shrink(),
+            "v.shrink().to_faces().shrink().to_edges().shrink()",
+            v.shrink().to_faces().shrink().to_edges().shrink(),
         ],
         [
             "as arrows - useful for orientation check!",
             e,
         ],
         [
-            "v.toedges(unique=False).shrink()\nas arrows",
+            "v.to_edges(unique=False).shrink()\nas arrows",
             direct_toedges,
         ],
     )

--- a/gustaf/_version.py
+++ b/gustaf/_version.py
@@ -2,4 +2,4 @@
 
 Current version.
 """
-version = "0.0.8"
+version = "0.0.9"

--- a/gustaf/create/edges.py
+++ b/gustaf/create/edges.py
@@ -26,7 +26,7 @@ def from_data(gus_obj, data, scale=None, data_norm=None):
     gus_obj: Vertices
       gus.Vertices or its derived classes
     data: str or (n_vertices, d) array-like
-     If str, will be considered as dataname and search for saved vertexdata.
+     If str, will be considered as data_name and search for saved vertexdata.
     scale: float
       Absolute value.
     data_norm: float or array-like

--- a/gustaf/create/edges.py
+++ b/gustaf/create/edges.py
@@ -12,7 +12,7 @@ def from_data(gus_obj, data, scale=None, data_norm=None):
     """
     Creates edges from gustaf object with vertices.
     Data can be either multi-dim array-like data or a str describing a name
-    of vertexdata that belongs to given gustaf object.
+    of vertex_data that belongs to given gustaf object.
     len(gus_obj.vertices) number of edges will be created, where origin and
     end of each edge is created using the following scheme:
     [[vertices[0], vertices[0] + (array_data[0] * scale)], ...].
@@ -26,7 +26,7 @@ def from_data(gus_obj, data, scale=None, data_norm=None):
     gus_obj: Vertices
       gus.Vertices or its derived classes
     data: str or (n_vertices, d) array-like
-     If str, will be considered as data_name and search for saved vertexdata.
+     If str, will be considered as data_name and search for saved vertex_data.
     scale: float
       Absolute value.
     data_norm: float or array-like
@@ -46,7 +46,7 @@ def from_data(gus_obj, data, scale=None, data_norm=None):
     origin = gus_obj.const_vertices
     if isinstance(data, str):
         # will raise if data doesn't exist
-        increment = gus_obj.vertexdata[data]
+        increment = gus_obj.vertex_data[data]
     elif isinstance(data, (tuple, list, np.ndarray)):
         increment = np.asanyarray(data)
         if len(increment) != len(origin):
@@ -83,7 +83,7 @@ def from_data(gus_obj, data, scale=None, data_norm=None):
     # apply default scale
     if scale is None:
         if isinstance(data, str):
-            norm = gus_obj.vertexdata.as_scalar(data, None, True)
+            norm = gus_obj.vertex_data.as_scalar(data, None, True)
         else:
             # compute
             if data_norm is None:

--- a/gustaf/create/faces.py
+++ b/gustaf/create/faces.py
@@ -39,7 +39,7 @@ def box(
         quad_mesh = box(bounds=bounds, resolutions=resolutions)
 
         # turn into triangles
-        face_mesh = tosimplex(quad_mesh, backslash)
+        face_mesh = to_simplex(quad_mesh, backslash)
 
     else:
         vertex_mesh = create.vertices.raster(bounds, resolutions)
@@ -49,10 +49,10 @@ def box(
     return face_mesh
 
 
-def tosimplex(quad, backslash=False):
+def to_simplex(quad, backslash=False):
     """Given quad faces, diagonalize them to turn them into triangles.
 
-    If quad is counterclockwiese (CCW), triangle will also be CCW and
+    If quad is counterclockwise (CCW), triangle will also be CCW and
     vice versa. Will return a tri-mesh, if input is triangular.
     Default diagonalization looks like this:
 
@@ -93,7 +93,7 @@ def tosimplex(quad, backslash=False):
 
     if not isinstance(quad, Faces):
         raise ValueError(
-            "Input to tosimplex needs to be of type Faces, but it's "
+            "Input to to_simplex needs to be of type Faces, but it's "
             + type(quad)
         )
 

--- a/gustaf/create/vertices.py
+++ b/gustaf/create/vertices.py
@@ -12,8 +12,8 @@ def raster(
     bounds,
     resolutions,
 ):
-    """Simple wraper of np.mgrid to extract raster points of desired bounds and
-    resolutions.
+    """Simple wrapper of np.mgrid to extract raster points of desired bounds
+    and resolutions.
 
     Parameters
     -----------

--- a/gustaf/edges.py
+++ b/gustaf/edges.py
@@ -413,15 +413,15 @@ class Edges(Vertices):
 
         return Edges(vertices=new_vs, edges=new_es)
 
-    def shrink(self, ratio=0.8, map_vertexdata=True):
+    def shrink(self, ratio=0.8, map_vertex_data=True):
         """Returns shrunk elements.
 
         Parameters
         -----------
         ratio: float
           Default is 0.8
-        map_vertexdata: bool
-          Default is True. Maps all vertexdata.
+        map_vertex_data: bool
+          Default is True. Maps all vertex_data.
 
         Returns
         --------
@@ -443,10 +443,10 @@ class Edges(Vertices):
 
         s_elements = type(self)(vertices=vs, elements=es)
 
-        if map_vertexdata:
+        if map_vertex_data:
             elements_flat = elements.ravel()
-            for key, value in self.vertexdata.items():
-                s_elements.vertexdata[key] = value[elements_flat]
+            for key, value in self.vertex_data.items():
+                s_elements.vertex_data[key] = value[elements_flat]
 
             # probably wanna take visulation options too
             s_elements._show_options._options = deepcopy(

--- a/gustaf/edges.py
+++ b/gustaf/edges.py
@@ -250,14 +250,14 @@ class Edges(Vertices):
         return getattr(self, elem_name)
 
     @elements.setter
-    def elements(self, elems):
+    def elements(self, elements):
         """Calls corresponding connectivity setter. A short cut in FEM friendly
         term. Vertices -> vertices Edges -> edges Faces -> faces Volumes ->
         volumes.
 
         Parameters
         -----------
-        elems: (n, d) np.ndarray
+        elements: (n, d) np.ndarray
 
         Returns
         --------
@@ -265,8 +265,8 @@ class Edges(Vertices):
         """
         # naming rule in gustaf
         elem_name = type(self).__qualname__.lower()
-        self._logd(f"seting {elem_name}'s connectivity.")
-        return setattr(self, elem_name, elems)
+        self._logd(f"Setting {elem_name}'s connectivity.")
+        return setattr(self, elem_name, elements)
 
     @property
     def const_elements(self):
@@ -398,7 +398,7 @@ class Edges(Vertices):
         for v0, v1, lins in zip(v0s, v1s, linspaces):
             new_vs.append(np.linspace(v0, v1, lins))
 
-        # we need all choped vertices.
+        # we need all chopped vertices.
         # there might be duplicating vertices. you can use merge_vertices
         new_vs = np.vstack(new_vs)
         # all mid points are explicitly defined, but they aren't required
@@ -448,14 +448,14 @@ class Edges(Vertices):
             for key, value in self.vertex_data.items():
                 s_elements.vertex_data[key] = value[elements_flat]
 
-            # probably wanna take visulation options too
+            # probably wanna take visualization options too
             s_elements._show_options._options = deepcopy(
                 self.show_options._options
             )
 
         return s_elements
 
-    def tovertices(self):
+    def to_vertices(self):
         """Returns Vertices obj.
 
         Parameters

--- a/gustaf/faces.py
+++ b/gustaf/faces.py
@@ -195,7 +195,7 @@ class Faces(Edges):
 
     @faces.setter
     def faces(self, fs):
-        """Faces setter. Similar to veritces, this will be a tracked array.
+        """Faces setter. Similar to vertices, this will be a tracked array.
 
         Parameters
         -----------
@@ -220,7 +220,7 @@ class Faces(Edges):
                 strict=True,
             )
 
-        # same, but non-writeable view of tracekd array
+        # same, but non-writeable view of tracked array
         self._const_faces = self._faces.view()
         self._const_faces.flags.writeable = False
 
@@ -298,7 +298,7 @@ class Faces(Edges):
         """Alias to update_elements."""
         self.update_elements(*args, **kwargs)
 
-    def toedges(self, unique=True):
+    def to_edges(self, unique=True):
         """Returns Edges obj.
 
         Parameters

--- a/gustaf/helpers/data.py
+++ b/gustaf/helpers/data.py
@@ -434,7 +434,7 @@ class VertexData(DataHolder):
         super().__init__(helpee)
 
     def _validate_len(self, value=None, raise_=True):
-        """Checks if given value is a valid vertexdata based of its length.
+        """Checks if given value is a valid vertex_data based of its length.
 
         If raise_, throws error, else, deletes all incompatible values.
         Only checks len(). If array has (1, len) shape, this will still return
@@ -490,7 +490,7 @@ class VertexData(DataHolder):
 
     def __setitem__(self, key, value):
         """
-        Performs len() based check before storing vertexdata.
+        Performs len() based check before storing vertex_data.
 
         Parameters
         ----------
@@ -684,7 +684,7 @@ class SplineDataAdaptor(GustafBase):
                 "function."
             )
 
-    def as_vertexdata(self, resolutions=None, on=None):
+    def as_vertex_data(self, resolutions=None, on=None):
         """
         Parameters
         ----------
@@ -693,7 +693,7 @@ class SplineDataAdaptor(GustafBase):
 
         Returns
         -------
-        vertexdata: (m, r) array-like
+        vertex_data: (m, r) array-like
         """
         if resolutions is not None and on is not None:
             raise ValueError(
@@ -815,7 +815,7 @@ class SplineData(DataHolder):
 
         saved = super().__getitem__(key)
         # will raise
-        return saved.as_vertexdata(resolutions=resolutions)
+        return saved.as_vertex_data(resolutions=resolutions)
 
     def as_arrow(self, key, resolutions=None, on=None, default=None):
         """
@@ -833,7 +833,7 @@ class SplineData(DataHolder):
 
         saved = super().__getitem__(key)
         # will raise
-        return saved.as_vertexdata(resolutions=resolutions, on=on)
+        return saved.as_vertex_data(resolutions=resolutions, on=on)
 
 
 Unique2DFloats = namedtuple(

--- a/gustaf/helpers/data.py
+++ b/gustaf/helpers/data.py
@@ -550,18 +550,18 @@ class VertexData(DataHolder):
         # interpret scalar as norm
         # save the norm once it is called.
         if "__norm" not in key:
-            normkey = key + "__norm"
+            norm_key = key + "__norm"
         else:
-            normkey = key
+            norm_key = key
             key = key.replace("__norm", "")
 
-        if normkey in self.keys():
-            saved = self[normkey]  # performs len check
+        if norm_key in self.keys():
+            saved = self[norm_key]  # performs len check
             # return if original is not modified
             if not self[key]._modified:  # check if original data is modified
                 return saved
             else:
-                self._saved.pop(normkey)
+                self._saved.pop(norm_key)
 
         # we are here because we have to compute norm. let's save norm
         value = self[key]
@@ -571,7 +571,7 @@ class VertexData(DataHolder):
             value_norm = np.linalg.norm(value, axis=1).reshape(-1, 1)
 
         # save norm
-        self[normkey] = value_norm
+        self[norm_key] = value_norm
         # considered not modified
         self[key]._modified = False
 

--- a/gustaf/helpers/data.py
+++ b/gustaf/helpers/data.py
@@ -620,7 +620,7 @@ class SplineDataAdaptor(GustafBase):
         "has_function",
         "has_locations",
         "has_evaluate",
-        "arrowdata_only",
+        "arrow_data_only",
         "_user_created",
     )
 
@@ -633,7 +633,7 @@ class SplineDataAdaptor(GustafBase):
         self.has_function = False
         self.has_locations = False
         self.has_evaluate = False
-        self.arrowdata_only = False
+        self.arrow_data_only = False
 
         # is spline we know?
         if "CoreSpline" in str(type(data).__mro__):
@@ -655,7 +655,7 @@ class SplineDataAdaptor(GustafBase):
         if locations is not None:
             # set what holds true
             self.has_locations = True
-            self.arrowdata_only = True
+            self.arrow_data_only = True
             self.locations = np.asanyarray(locations)
 
             # if this is not a spline we know, it doesn't have a function,

--- a/gustaf/helpers/options.py
+++ b/gustaf/helpers/options.py
@@ -54,7 +54,7 @@ vedo_common_options = (
     Option("vedo", "alpha", "Transparency in range [0, 1].", (float, int)),
     Option(
         "vedo",
-        "dataname",
+        "data_name",
         "Name of vertexdata to show. "
         "Object must have vertexdata with the same name.",
         (str,),

--- a/gustaf/helpers/options.py
+++ b/gustaf/helpers/options.py
@@ -89,7 +89,7 @@ vedo_common_options = (
     ),
     Option(
         "vedo",
-        "arrowdata",
+        "arrow_data",
         "Name of vertexdata to plot as arrow. Corresponding data should be "
         "at least 2D. If you want more control over arrows, consider creating "
         "edges using gus.create.edges.from_data().",
@@ -97,13 +97,13 @@ vedo_common_options = (
     ),
     Option(
         "vedo",
-        "arrowdata_scale",
+        "arrow_data_scale",
         "Scaling factor for arrow data.",
         (float, int),
     ),
     Option(
         "vedo",
-        "arrowdata_color",
+        "arrow_data_color",
         "Color for arrow data. Can be either cmap name or color. For "
         "cmap, colors are based on the size of the arrows.",
         (str, tuple, list, int),

--- a/gustaf/helpers/options.py
+++ b/gustaf/helpers/options.py
@@ -55,8 +55,8 @@ vedo_common_options = (
     Option(
         "vedo",
         "data_name",
-        "Name of vertexdata to show. "
-        "Object must have vertexdata with the same name.",
+        "Name of vertex_data to show. "
+        "Object must have vertex_data with the same name.",
         (str,),
     ),
     Option("vedo", "vertex_ids", "Show ids of vertices", (bool,)),
@@ -68,7 +68,7 @@ vedo_common_options = (
         "'glossy', 'ambient', 'off'}",
         (str,),
     ),
-    Option("vedo", "cmap", "Colormap for vertexdata plots.", (str,)),
+    Option("vedo", "cmap", "Colormap for vertex_data plots.", (str,)),
     Option("vedo", "vmin", "Minimum value for cmap", (float, int)),
     Option("vedo", "vmax", "Maximum value for cmap", (float, int)),
     Option(
@@ -90,7 +90,7 @@ vedo_common_options = (
     Option(
         "vedo",
         "arrow_data",
-        "Name of vertexdata to plot as arrow. Corresponding data should be "
+        "Name of vertex_data to plot as arrow. Corresponding data should be "
         "at least 2D. If you want more control over arrows, consider creating "
         "edges using gus.create.edges.from_data().",
         (str,),

--- a/gustaf/helpers/options.py
+++ b/gustaf/helpers/options.py
@@ -73,7 +73,7 @@ vedo_common_options = (
     Option("vedo", "vmax", "Maximum value for cmap", (float, int)),
     Option(
         "vedo",
-        "cmapalpha",
+        "cmap_alpha",
         "Colormap Transparency in range [0, 1].",
         (float, int),
     ),
@@ -148,7 +148,7 @@ def make_valid_options(*options):
 class ShowOption:
     """
     Behaves similar to dict, but will only accept a set of options that's
-    applicable to the helpee class. Intented use is to create a
+    applicable to the helpee class. Intended use is to create a
     subclass that would define valid options for helpee.
     Options should be described by Option object.
     Helps all the way up to initializing backend showables up to their backend
@@ -388,7 +388,7 @@ class ShowOption:
 
     def copy_valid_options(self, copy_to, keys=None):
         """
-        Copies valid option to other showopts. Simply iterates and treis.
+        Copies valid option to other show_option. Simply iterates and tries.
 
         Parameters
         ----------

--- a/gustaf/io/mixd.py
+++ b/gustaf/io/mixd.py
@@ -81,10 +81,10 @@ def load(
         bcs_in = np.fromfile(mrng, dtype=">i").astype(np.int32)  # flattened
         uniq_bcs_in = np.unique(bcs_in)
         uniq_bcs_in = uniq_bcs_in[uniq_bcs_in > 0]  # keep only natural nums
-        subelemids = np.arange(bcs_in.size)
+        sub_elem_ids = np.arange(bcs_in.size)
 
         for ubci in uniq_bcs_in:
-            bcs.update({str(ubci): subelemids[bcs_in == ubci]})
+            bcs.update({str(ubci): sub_elem_ids[bcs_in == ubci]})
 
     except BaseException:
         log.debug(f"mrng file, `{mrng}`, does not exist. Skipping.")
@@ -121,7 +121,7 @@ def export(
     mesh: Faces or Volumes
     fname: str
     space_time : bool
-      Export Mesh as Space-Time Slab for discontinous space-time
+      Export Mesh as Space-Time Slab for discontinuous space-time
 
     Returns
     --------
@@ -229,7 +229,7 @@ def make_mrng(mesh):
       The mrng-array.
     """
 
-    # determine number of subelements
+    # determine number of sub elements
     whatami = mesh.whatami
     nbelem = 3
 

--- a/gustaf/io/nutils.py
+++ b/gustaf/io/nutils.py
@@ -24,13 +24,13 @@ def load(fname):
     --------
     mesh: Faces or Volumes
     """
-    npzfile = np.load(fname, allow_pickle=True)
-    nodes = npzfile["nodes"]
-    _ = npzfile["cnodes"]
-    coords = npzfile["coords"]
-    _ = npzfile["tags"].item()
-    btags = npzfile["btags"].item()
-    _ = npzfile["ptags"].item()
+    npz_file = np.load(fname, allow_pickle=True)
+    nodes = npz_file["nodes"]
+    _ = npz_file["cnodes"]
+    coords = npz_file["coords"]
+    _ = npz_file["tags"].item()
+    btags = npz_file["btags"].item()
+    _ = npz_file["ptags"].item()
 
     if nodes.shape[0] == 0:
         raise TypeError("Can not find nodes. Check nutils mesh description.")
@@ -133,7 +133,7 @@ def to_nutils_simplex(mesh):
     bound_id = np.unique(bcs_in)
     bound_id = bound_id[bound_id > 0]
 
-    # Reorder the mrng according to nutils permutation: swap collumns
+    # Reorder the mrng according to nutils permutation: swap columns
     bcs_in[:, :] = bcs_in[:, permutation]
 
     # Let's reorder the bcs file with the sort_array

--- a/gustaf/show.py
+++ b/gustaf/show.py
@@ -35,12 +35,12 @@ class _CallableShowDotPy(sys.modules[__name__].__class__):
 sys.modules[__name__].__class__ = _CallableShowDotPy
 
 
-def show(*gusobj, **kwargs):
+def show(*gus_obj, **kwargs):
     """Shows using appropriate backend.
 
     Parameters
     -----------
-    *gusobj: gustaf objects
+    *gus_obj: gustaf objects
 
     Returns
     --------
@@ -49,7 +49,7 @@ def show(*gusobj, **kwargs):
     vis_b = settings.VISUALIZATION_BACKEND
 
     if vis_b.startswith("vedo"):
-        return show_vedo(*gusobj, **kwargs)
+        return show_vedo(*gus_obj, **kwargs)
     elif vis_b.startswith("trimesh"):
         pass
     elif vis_b.startswith("matplotlib"):
@@ -72,7 +72,7 @@ def show_vedo(
     # vedo plotter parameter
     N = len(args)
     offs = kwargs.get("offscreen", False)
-    interac = kwargs.get("interactive", True)
+    interact = kwargs.get("interactive", True)
     plt = kwargs.get("vedoplot", None)
     skip_clear = kwargs.get("skip_clear", False)
     close = kwargs.get("close", None)
@@ -81,27 +81,27 @@ def show_vedo(
     title = kwargs.get("title", "gustaf")
     return_show_list = kwargs.get("return_showable_list", False)
 
-    def clear_vedoplotter(plotter, numrenderers, skipcl=skip_clear):
+    def clear_vedo_plotter(plotter, num_renderers, skip_cl=skip_clear):
         """enough said."""
         # for whatever reason it is desired
-        if skipcl:
+        if skip_cl:
             return None
 
-        for i in range(numrenderers):
+        for i in range(num_renderers):
             plotter.clear(at=i)
 
         return None
 
-    def cam_tuple_to_list(dictcam):
+    def cam_tuple_to_list(dict_cam):
         """if entity is tuple, turns it into list."""
-        if dictcam is None:
+        if dict_cam is None:
             return None
 
-        for key, value in dictcam.items():
+        for key, value in dict_cam.items():
             if isinstance(value, tuple):
-                dictcam[key] = list(value)
+                dict_cam[key] = list(value)
 
-        return dictcam
+        return dict_cam
 
     # get plotter
     if plt is None:
@@ -112,7 +112,7 @@ def show_vedo(
     else:
         # check if plt has enough Ns
         trueN = np.prod(plt.shape)
-        clear_vedoplotter(plt, trueN)  # always clear.
+        clear_vedo_plotter(plt, trueN)  # always clear.
         if trueN != N:
             utils.log.warning(
                 "Number of args exceed given vedo.Plotter's capacity.",
@@ -120,7 +120,7 @@ def show_vedo(
             )
             title = plt.title
             if close:  # only if it is explicitly stated
-                plt.close()  # Hope that this truely releases..
+                plt.close()  # Hope that this truly releases..
             # assign a new one
             plt = vedo.Plotter(
                 N=N, sharecam=False, offscreen=offs, size=size, title=title
@@ -130,9 +130,9 @@ def show_vedo(
     for i, arg in enumerate(args):
         # form valid input type.
         if isinstance(arg, dict):
-            showlist = list(arg.values())
+            show_list = list(arg.values())
         elif isinstance(arg, list):
-            showlist = arg.copy()
+            show_list = arg.copy()
         else:
             # raise TypeError(
             #     "For vedo_show, only list or dict is valid input")
@@ -140,16 +140,16 @@ def show_vedo(
                 "one of args for show_vedo is neither `dict` nor",
                 "`list`. Putting it naively into a list.",
             )
-            showlist = [arg]
+            show_list = [arg]
 
-        # quickcheck if the list is gustaf or non-gustaf
+        # quick check if the list is gustaf or non-gustaf
         # if gustaf, make it vedo-showable.
         # if there's spline, we need to pop the element and
         # extend showables to the list.
-        # A showlist is a list to be plotted into a single subframe of the
+        # A show_list is a list to be plotted into a single sub frame of the
         # plot
         list_of_showables = []
-        for sl in showlist:
+        for sl in show_list:
             if not isinstance(sl, list):
                 sl = [sl]
             for k, item in enumerate(sl):
@@ -160,9 +160,8 @@ def show_vedo(
                     if isinstance(tmp_showable, dict):
                         # add to extend later
                         list_of_showables.extend(list(tmp_showable.values()))
-
                     else:
-                        # replace gustafobj with vedo_obj.
+                        # replace gustaf_obj with vedo_obj.
                         list_of_showables.append(tmp_showable)
                 else:
                     list_of_showables.extend(sl)
@@ -171,7 +170,7 @@ def show_vedo(
             plt.show(
                 list_of_showables,
                 at=i,
-                interactive=interac,
+                interactive=interact,
                 camera=cam_tuple_to_list(cam),
                 # offscreen=offs,
             )
@@ -185,9 +184,9 @@ def show_vedo(
                 # offscreen=offs,
             )
 
-    if interac and not offs:
+    if interact and not offs:
         # only way to ensure memory is released
-        clear_vedoplotter(plt, np.prod(plt.shape))
+        clear_vedo_plotter(plt, np.prod(plt.shape))
 
         if close or close is None:  # explicitly given or None.
             # It seems to leak some memory, but here it goes.
@@ -208,7 +207,7 @@ def _vedo_showable(obj, as_dict=False, **kwargs):
     -----------
     obj: gustaf obj
     as_dict: bool
-      If True, returns vedo objects in a dict. Corresponding main objecst will
+      If True, returns vedo objects in a dict. Corresponding main objects will
       be available with ["main"] key. Else, returns vedo.Assembly object,
       where all the objects are grouped together.
     **kwargs: kwargs
@@ -235,7 +234,7 @@ def _vedo_showable(obj, as_dict=False, **kwargs):
                 )
                 continue
 
-    # minimal-initalization of vedo objects
+    # minimal-initialization of vedo objects
     vedo_obj = obj.show_options._initialize_showable()
     # as dict?
     if as_dict:
@@ -267,7 +266,7 @@ def _vedo_showable(obj, as_dict=False, **kwargs):
             )
             element_ids = False
     if vertex_ids:
-        # use vtk font. supposedly faster. And differs from cellid.
+        # use vtk font. supposedly faster. And differs from cell id.
         vertex_ids = vedo_obj.labels("id", on="points", font="VTK")
         if not as_dict:
             vedo_obj += vertex_ids
@@ -296,7 +295,7 @@ def _vedo_showable(obj, as_dict=False, **kwargs):
         # form cmap kwargs for init
         cmap_keys = ("vmin", "vmax")
         cmap_kwargs = obj.show_options[cmap_keys]
-        # set adefault cmap if needed
+        # set a default cmap if needed
         cmap_kwargs["input_cmap"] = obj.show_options.get("cmap", "plasma")
         cmap_kwargs["alpha"] = obj.show_options.get("cmap_alpha", 1)
         # add data_name
@@ -306,7 +305,7 @@ def _vedo_showable(obj, as_dict=False, **kwargs):
         vedo_obj.cmap(**cmap_kwargs)
 
         # at last, scalarbar
-        # deprecated function name, keeep it for now for backward compat
+        # deprecated function name, keep it for now for backward compat
         sb_kwargs = obj.show_options.get("scalarbar", None)
         if sb_kwargs is not None and sb_kwargs is not False:
             sb_kwargs = dict() if isinstance(sb_kwargs, bool) else sb_kwargs
@@ -382,7 +381,7 @@ def make_showable(obj, backend=settings.VISUALIZATION_BACKEND, **kwargs):
     """Since gustaf does not natively support visualization, one of the
     following library is used to visualize gustaf (visualizable) objects: (1)
     vedo -> Fast, offers a lot of features (2) trimesh -> Fast, compatible with
-    old opengl (3) matplotlib -> Slow, offers vector graphics.
+    old OpenGL (3) matplotlib -> Slow, offers vector graphics.
 
     This determines showing types using `whatami`.
 
@@ -395,7 +394,7 @@ def make_showable(obj, backend=settings.VISUALIZATION_BACKEND, **kwargs):
 
     Returns
     --------
-    showalbe_objs: list
+    showable_objs: list
       List of showable objects.
     """
     if backend.startswith("vedo"):
@@ -408,7 +407,8 @@ def make_showable(obj, backend=settings.VISUALIZATION_BACKEND, **kwargs):
         raise NotImplementedError
 
 
-# possibly relocate
+# possibly relocate, is this actually used?
+# could not find any usage in this repo
 def interpolate_vedo_dictcam(cameras, resolutions, spline_degree=1):
     """Interpolate between vedo dict cameras.
 
@@ -433,12 +433,12 @@ def interpolate_vedo_dictcam(cameras, resolutions, spline_degree=1):
         spp = False
 
     # quick type check loop
-    camkeys = ["pos", "focalPoint", "viewup", "distance", "clippingRange"]
+    cam_keys = ["pos", "focalPoint", "viewup", "distance", "clippingRange"]
     for cam in cameras:
         if not isinstance(cam, dict):
             raise TypeError("Only `dict` description of vedo cam is allowed.")
         else:
-            for key in camkeys:
+            for key in cam_keys:
                 if cam[key] is None:
                     raise ValueError(
                         f"One of the camera does not contain `{key}` info"
@@ -460,54 +460,54 @@ def interpolate_vedo_dictcam(cameras, resolutions, spline_degree=1):
         ds = []
         cs = []
         for cam in cameras:
-            ps.append(list(cam[camkeys[0]]))
-            fs.append(list(cam[camkeys[1]]))
-            vs.append(list(cam[camkeys[2]]))
-            ds.append([float(cam[camkeys[3]])])
-            cs.append(list(cam[camkeys[4]]))
+            ps.append(list(cam[cam_keys[0]]))
+            fs.append(list(cam[cam_keys[1]]))
+            vs.append(list(cam[cam_keys[2]]))
+            ds.append([float(cam[cam_keys[3]])])
+            cs.append(list(cam[cam_keys[4]]))
 
         interpolated = dict()
         for i, prop in enumerate([ps, fs, vs, ds, cs]):
-            ispline = splinepy.BSpline()
-            ispline.interpolate_curve(
+            i_spline = splinepy.BSpline()
+            i_spline.interpolate_curve(
                 query_points=prop,
                 degree=spline_degree,
                 save_query=False,
             )
-            interpolated[camkeys[i]] = ispline.sample([total_cams])
+            interpolated[cam_keys[i]] = i_spline.sample([total_cams])
 
         for i in range(total_cams):
             interpolated_cams.append(
                 {
-                    camkeys[0]: interpolated[camkeys[0]][i].tolist(),
-                    camkeys[1]: interpolated[camkeys[1]][i].tolist(),
-                    camkeys[2]: interpolated[camkeys[2]][i].tolist(),
-                    camkeys[3]: interpolated[camkeys[3]][i][0],  # float?
-                    camkeys[4]: interpolated[camkeys[4]][i].tolist(),
+                    cam_keys[0]: interpolated[cam_keys[0]][i].tolist(),
+                    cam_keys[1]: interpolated[cam_keys[1]][i].tolist(),
+                    cam_keys[2]: interpolated[cam_keys[2]][i].tolist(),
+                    cam_keys[3]: interpolated[cam_keys[3]][i][0],  # float?
+                    cam_keys[4]: interpolated[cam_keys[4]][i].tolist(),
                 }
             )
 
     else:
         i = 0
-        for startcam, endcam in zip(cameras[:-1], cameras[1:]):
+        for start_cam, end_cam in zip(cameras[:-1], cameras[1:]):
             if i == 0:
                 interpolated = [
                     np.linspace(
-                        startcam[ckeys],
-                        endcam[ckeys],
+                        start_cam[ckeys],
+                        end_cam[ckeys],
                         resolutions,
                     ).tolist()
-                    for ckeys in camkeys
+                    for ckeys in cam_keys
                 ]
 
             else:
                 interpolated = [
                     np.linspace(
-                        startcam[ckeys],
-                        endcam[ckeys],
+                        start_cam[ckeys],
+                        end_cam[ckeys],
                         int(resolutions + 1),
                     )[1:].tolist()
-                    for ckeys in camkeys
+                    for ckeys in cam_keys
                 ]
 
             i += 1
@@ -515,11 +515,11 @@ def interpolate_vedo_dictcam(cameras, resolutions, spline_degree=1):
             for j in range(resolutions):
                 interpolated_cams.append(
                     {
-                        camkeys[0]: interpolated[0][j],
-                        camkeys[1]: interpolated[1][j],
-                        camkeys[2]: interpolated[2][j],
-                        camkeys[3]: interpolated[3][j],  # float?
-                        camkeys[4]: interpolated[4][j],
+                        cam_keys[0]: interpolated[0][j],
+                        cam_keys[1]: interpolated[1][j],
+                        cam_keys[2]: interpolated[2][j],
+                        cam_keys[3]: interpolated[3][j],  # float?
+                        cam_keys[4]: interpolated[4][j],
                     }
                 )
 

--- a/gustaf/show.py
+++ b/gustaf/show.py
@@ -283,15 +283,15 @@ def _vedo_showable(obj, as_dict=False, **kwargs):
 
     # data plotting
     data_name = obj.show_options.get("data_name", None)
-    vertexdata = obj.vertexdata.as_scalar(data_name, None)
-    if data_name is not None and vertexdata is not None:
+    vertex_data = obj.vertex_data.as_scalar(data_name, None)
+    if data_name is not None and vertex_data is not None:
         # transfer data
         if obj.kind.startswith("edge"):
-            vedo_obj.pointdata[data_name] = vertexdata[obj.edges].reshape(
-                -1, vertexdata.shape[1]
+            vedo_obj.pointdata[data_name] = vertex_data[obj.edges].reshape(
+                -1, vertex_data.shape[1]
             )
         else:
-            vedo_obj.pointdata[data_name] = vertexdata
+            vedo_obj.pointdata[data_name] = vertex_data
 
         # form cmap kwargs for init
         cmap_keys = ("vmin", "vmax")
@@ -312,15 +312,15 @@ def _vedo_showable(obj, as_dict=False, **kwargs):
             sb_kwargs = dict() if isinstance(sb_kwargs, bool) else sb_kwargs
             vedo_obj.addScalarBar(**sb_kwargs)
 
-    elif data_name is not None and vertexdata is None:
+    elif data_name is not None and vertex_data is None:
         utils.log.debug(
-            f"No vertexdata named '{data_name}' for {obj}. Skipping"
+            f"No vertex_data named '{data_name}' for {obj}. Skipping"
         )
 
     # arrow plots - this is independent from data plotting.
     arrow_data_name = obj.show_options.get("arrow_data", None)
     # will raise if data is scalar
-    arrow_data_value = obj.vertexdata.as_arrow(arrow_data_name, None, True)
+    arrow_data_value = obj.vertex_data.as_arrow(arrow_data_name, None, True)
     if arrow_data_name is not None and arrow_data_value is not None:
         from gustaf.create.edges import from_data
 
@@ -336,7 +336,7 @@ def _vedo_showable(obj, as_dict=False, **kwargs):
             obj,
             arrow_data_value,
             obj.show_options.get("arrow_data_scale", None),
-            data_norm=obj.vertexdata.as_scalar(arrow_data_name),
+            data_norm=obj.vertex_data.as_scalar(arrow_data_name),
         )
         arrows = vedo.Arrows(
             as_edges.vertices[as_edges.edges],

--- a/gustaf/show.py
+++ b/gustaf/show.py
@@ -318,34 +318,34 @@ def _vedo_showable(obj, as_dict=False, **kwargs):
         )
 
     # arrow plots - this is independent from data plotting.
-    arrowdata_name = obj.show_options.get("arrowdata", None)
+    arrow_data_name = obj.show_options.get("arrow_data", None)
     # will raise if data is scalar
-    arrowdata_value = obj.vertexdata.as_arrow(arrowdata_name, None, True)
-    if arrowdata_name is not None and arrowdata_value is not None:
+    arrow_data_value = obj.vertexdata.as_arrow(arrow_data_name, None, True)
+    if arrow_data_name is not None and arrow_data_value is not None:
         from gustaf.create.edges import from_data
 
         # we are here because this data is not a scalar
         # is showable?
-        if arrowdata_value.shape[1] not in (2, 3):
+        if arrow_data_value.shape[1] not in (2, 3):
             raise ValueError(
                 "Only 2D or 3D data can be shown.",
-                f"Requested data is {arrowdata_value.shape[1]}",
+                f"Requested data is {arrow_data_value.shape[1]}",
             )
 
         as_edges = from_data(
             obj,
-            arrowdata_value,
-            obj.show_options.get("arrowdata_scale", None),
-            data_norm=obj.vertexdata.as_scalar(arrowdata_name),
+            arrow_data_value,
+            obj.show_options.get("arrow_data_scale", None),
+            data_norm=obj.vertexdata.as_scalar(arrow_data_name),
         )
         arrows = vedo.Arrows(
             as_edges.vertices[as_edges.edges],
-            c=obj.show_options.get("arrowdata_color", "plasma"),
+            c=obj.show_options.get("arrow_data_color", "plasma"),
         )
         if not as_dict:
             vedo_obj += arrows
         else:
-            return_as_dict["arrowdata"] = arrows
+            return_as_dict["arrow_data"] = arrows
 
     axes_kw = obj.show_options.get("axes", None)
     # need to explicitly check if it is false

--- a/gustaf/show.py
+++ b/gustaf/show.py
@@ -297,7 +297,7 @@ def _vedo_showable(obj, as_dict=False, **kwargs):
         cmap_keys = ("vmin", "vmax")
         cmap_kwargs = obj.show_options[cmap_keys]
         # set adefault cmap if needed
-        cmap_kwargs["cname"] = obj.show_options.get("cmap", "plasma")
+        cmap_kwargs["input_cmap"] = obj.show_options.get("cmap", "plasma")
         cmap_kwargs["alpha"] = obj.show_options.get("cmap_alpha", 1)
         # add data_name
         cmap_kwargs["input_array"] = data_name

--- a/gustaf/show.py
+++ b/gustaf/show.py
@@ -298,7 +298,7 @@ def _vedo_showable(obj, as_dict=False, **kwargs):
         cmap_kwargs = obj.show_options[cmap_keys]
         # set adefault cmap if needed
         cmap_kwargs["cname"] = obj.show_options.get("cmap", "plasma")
-        cmap_kwargs["alpha"] = obj.show_options.get("cmapalpha", 1)
+        cmap_kwargs["alpha"] = obj.show_options.get("cmap_alpha", 1)
         # add data_name
         cmap_kwargs["input_array"] = data_name
 

--- a/gustaf/show.py
+++ b/gustaf/show.py
@@ -282,16 +282,16 @@ def _vedo_showable(obj, as_dict=False, **kwargs):
             return_as_dict["element_ids"] = element_ids
 
     # data plotting
-    dataname = obj.show_options.get("dataname", None)
-    vertexdata = obj.vertexdata.as_scalar(dataname, None)
-    if dataname is not None and vertexdata is not None:
+    data_name = obj.show_options.get("data_name", None)
+    vertexdata = obj.vertexdata.as_scalar(data_name, None)
+    if data_name is not None and vertexdata is not None:
         # transfer data
         if obj.kind.startswith("edge"):
-            vedo_obj.pointdata[dataname] = vertexdata[obj.edges].reshape(
+            vedo_obj.pointdata[data_name] = vertexdata[obj.edges].reshape(
                 -1, vertexdata.shape[1]
             )
         else:
-            vedo_obj.pointdata[dataname] = vertexdata
+            vedo_obj.pointdata[data_name] = vertexdata
 
         # form cmap kwargs for init
         cmap_keys = ("vmin", "vmax")
@@ -299,8 +299,8 @@ def _vedo_showable(obj, as_dict=False, **kwargs):
         # set adefault cmap if needed
         cmap_kwargs["cname"] = obj.show_options.get("cmap", "plasma")
         cmap_kwargs["alpha"] = obj.show_options.get("cmapalpha", 1)
-        # add dataname
-        cmap_kwargs["input_array"] = dataname
+        # add data_name
+        cmap_kwargs["input_array"] = data_name
 
         # set cmap
         vedo_obj.cmap(**cmap_kwargs)
@@ -312,9 +312,9 @@ def _vedo_showable(obj, as_dict=False, **kwargs):
             sb_kwargs = dict() if isinstance(sb_kwargs, bool) else sb_kwargs
             vedo_obj.addScalarBar(**sb_kwargs)
 
-    elif dataname is not None and vertexdata is None:
+    elif data_name is not None and vertexdata is None:
         utils.log.debug(
-            f"No vertexdata named '{dataname}' for {obj}. Skipping"
+            f"No vertexdata named '{data_name}' for {obj}. Skipping"
         )
 
     # arrow plots - this is independent from data plotting.

--- a/gustaf/spline/base.py
+++ b/gustaf/spline/base.py
@@ -113,7 +113,7 @@ class GustafSpline(GustafBase):
         self._proximity = Proximity(self)
         self._creator = Creator(self)
         self._show_options = self.__show_option__(self)
-        self._splinedata = SplineData(self)
+        self._spline_data = SplineData(self)
 
     @property
     def show_options(self):
@@ -131,7 +131,7 @@ class GustafSpline(GustafBase):
         return self._show_options
 
     @property
-    def splinedata(self):
+    def spline_data(self):
         """
         Spline data helper for splines.
 
@@ -141,9 +141,9 @@ class GustafSpline(GustafBase):
 
         Returns
         -------
-        splinedata: SplineData
+        spline_data: SplineData
         """
-        return self._splinedata
+        return self._spline_data
 
     @property
     def extract(self):

--- a/gustaf/spline/base.py
+++ b/gustaf/spline/base.py
@@ -18,8 +18,9 @@ from gustaf.spline.proximity import Proximity
 
 
 def show(spline, **kwargs):
-    """Shows splines with various options. They are excessively listed, so that
-    it can be adjustable.
+    """Shows splines with various options.
+
+    They are excessively listed, so that it can be adjustable.
 
     Parameters
     -----------
@@ -104,7 +105,7 @@ class GustafSpline(GustafBase):
     __show_option__ = visualize.SplineShowOption
 
     def __init__(self):
-        """Contructor as abstractmethod.
+        """Constructor as abstractmethod.
 
         This needs to be inherited first to make sure duplicating
         functions properly override splinepy.Spline
@@ -147,13 +148,13 @@ class GustafSpline(GustafBase):
 
     @property
     def extract(self):
-        """Returns spline extracter. Can directly perform extractions available
+        """Returns spline extractor. Can directly perform extractions available
         at `gustaf/spline/extract.py`. For more info, take a look at
-        `gustaf/spline/extract.py`: Extracter.
+        `gustaf/spline/extract.py`: Extractor.
 
         Examples
         ---------
-        >>> splinefaces = spline.extract.faces()
+        >>> spline_faces = spline.extract.faces()
 
         Parameters
         -----------
@@ -161,7 +162,7 @@ class GustafSpline(GustafBase):
 
         Returns
         --------
-        spline_extracter: Extracter
+        spline_extractor: Extractor
         """
         return self._extractor
 

--- a/gustaf/spline/create.py
+++ b/gustaf/spline/create.py
@@ -261,7 +261,7 @@ def from_bounds(parametric_bounds, physical_bounds):
     physical_bounds = np.asanyarray(physical_bounds).reshape(2, -1)
     parametric_bounds = np.asanyarray(parametric_bounds).reshape(2, -1)
 
-    # get correctly sized bezbox
+    # get correctly sized bez box
     phys_size = physical_bounds[1] - physical_bounds[0]
 
     # minimal bspline
@@ -271,8 +271,8 @@ def from_bounds(parametric_bounds, physical_bounds):
     # update parametric bounds
     for i, kv in enumerate(bspline_box.kvs):
         # apply scale and offset
-        newkv = (kv * parametric_bounds[1][i]) + parametric_bounds[0][i]
-        bspline_box.kvs[i] = newkv
+        new_kv = (kv * parametric_bounds[1][i]) + parametric_bounds[0][i]
+        bspline_box.kvs[i] = new_kv
 
     return bspline_box
 
@@ -315,13 +315,13 @@ def parametric_view(spline, axes=True):
         # configure axes
         bs = p_bounds
         bs_diff_001 = (bs[1] - bs[0]) * 0.001
-        lowerb = bs[0] - bs_diff_001
-        upperb = bs[1] + bs_diff_001
+        lower_b = bs[0] - bs_diff_001
+        upper_b = bs[1] + bs_diff_001
         axes_config = dict(
             xtitle="u",
             ytitle="v",
-            xrange=[lowerb[0], upperb[0]],
-            yrange=[lowerb[1], upperb[1]],
+            xrange=[lower_b[0], upper_b[0]],
+            yrange=[lower_b[1], upper_b[1]],
             tip_size=0,
             xminor_ticks=3,
             yminor_ticks=3,
@@ -330,7 +330,7 @@ def parametric_view(spline, axes=True):
         )
         if spline.para_dim == 3:
             axes_config.update(ztitle="w")
-            axes_config.update(zrange=[lowerb[2], upperb[2]])
+            axes_config.update(zrange=[lower_b[2], upper_b[2]])
             axes_config.update(zminor_ticks=3)
             axes_config.update(zxgrid=False)
 
@@ -420,16 +420,16 @@ def arc(
         point_spline = point_spline.nurbs
 
     # Revolve - set degree to False, since all the angles are converted to rad
-    arc_attribs = point_spline.create.revolved(
+    arc_attrib = point_spline.create.revolved(
         angle=angle, n_knot_spans=n_knot_spans, degree=False
     ).todict()
-    # Remove the first parametric dimenions, which is only a point and
+    # Remove the first parametric dimensions, which is only a point and
     # only used for the revolution
-    arc_attribs["degrees"] = list(arc_attribs["degrees"])[1:]
+    arc_attrib["degrees"] = list(arc_attrib["degrees"])[1:]
     if point_spline.has_knot_vectors:
-        arc_attribs["knot_vectors"] = list(arc_attribs["knot_vectors"])[1:]
+        arc_attrib["knot_vectors"] = list(arc_attrib["knot_vectors"])[1:]
 
-    return type(point_spline)(**arc_attribs)
+    return type(point_spline)(**arc_attrib)
 
 
 def circle(radius=1.0, n_knot_spans=3):
@@ -451,7 +451,7 @@ def circle(radius=1.0, n_knot_spans=3):
 
 
 def box(*lengths):
-    """ND box (hyperrectangle).
+    """ND box (hyper rectangle).
 
     Parameters
     ----------
@@ -459,18 +459,18 @@ def box(*lengths):
 
     Returns
     -------
-    ndbox: Bezier
+    nd_box: Bezier
     """
     from gustaf import Bezier
 
     # may dim check here?
     # starting point
-    ndbox = Bezier(degrees=[1], control_points=[[0], [lengths[0]]])
+    nd_box = Bezier(degrees=[1], control_points=[[0], [lengths[0]]])
     # use extrude
     for i, l in enumerate(lengths[1:]):
-        ndbox = ndbox.create.extruded([0] * int(i + 1) + [l])
+        nd_box = nd_box.create.extruded([0] * int(i + 1) + [l])
 
-    return ndbox
+    return nd_box
 
 
 def plate(radius=1.0):
@@ -577,7 +577,7 @@ def torus(
     section_inner_radius : float, optional
       Inner radius in case of hollow torus, by default 0.
     torus_angle : float, optional
-      Rotational anlge of the torus, by default None, giving a complete
+      Rotational angle of the torus, by default None, giving a complete
       revolution
     section_angle : float, optional
       Rotational angle, by default None, yielding a complete revolution
@@ -703,7 +703,7 @@ def cone(
     Returns
     -------
     cone: NURBS
-      Volumetric or surface NURBS descibing a cone
+      Volumetric or surface NURBS describing a cone
     """
 
     if volumetric:
@@ -733,7 +733,7 @@ def pyramid(width, length, height):
     ----------
     width : float
       Dimension of base in x-axis
-    lenght : float
+    length : float
       Dimension of base in y-axis
     height : float
       Height in z-direction
@@ -758,8 +758,8 @@ class Creator:
 
     Examples
     ---------
-    >>> myspline = <your-spline>
-    >>> spline_faces = myspline.create.extrude(vector=[3,1,3])
+    >>> my_spline = <your-spline>
+    >>> spline_faces = my_spline.create.extrude(vector=[3,1,3])
     """
 
     def __init__(self, spl):

--- a/gustaf/spline/create.py
+++ b/gustaf/spline/create.py
@@ -282,7 +282,7 @@ def parametric_view(spline, axes=True):
     `naive_spline()`. Degrees are always 1 and knot multiplicity is not
     preserved. Returns BSpline, as BSpline and NURBS should look the same as
     parametric view.
-    Will take shallow copy of underlying data of splinedata and show_options
+    Will take shallow copy of underlying data of spline_data and show_options
     from original spline.
 
     Parameters
@@ -306,7 +306,7 @@ def parametric_view(spline, axes=True):
             para_spline.insert_knots(i, kv[1:-1])
 
     # take shallow copy
-    para_spline._splinedata._saved = spline.splinedata._saved.copy()
+    para_spline._spline_data._saved = spline.spline_data._saved.copy()
     para_spline._show_options._options[
         para_spline._show_options._backend
     ] = spline.show_options._options[spline._show_options._backend].copy()

--- a/gustaf/spline/ffd.py
+++ b/gustaf/spline/ffd.py
@@ -461,7 +461,7 @@ class FFD(GustafBase):
             return things_to_show
 
         if return_showable:
-            # let's turn everthing into showable and return
+            # let's turn everything into showable and return
             for k, v in things_to_show.items():
                 if isinstance(v, GustafBase):
                     things_to_show[k] = v.showable()

--- a/gustaf/spline/ffd.py
+++ b/gustaf/spline/ffd.py
@@ -442,9 +442,9 @@ class FFD(GustafBase):
         # let's show faces at most, since volumes can take awhile
         if o_mesh.kind == "volume":
             # only outer faces. overwrite
-            o_mesh = o_mesh.tofaces(unique=False)
+            o_mesh = o_mesh.to_faces(unique=False)
             o_mesh.update_faces(o_mesh.single_faces())
-            d_mesh = d_mesh.tofaces(unique=False)
+            d_mesh = d_mesh.to_faces(unique=False)
             d_mesh.update_faces(d_mesh.single_faces())
 
         # update meshes

--- a/gustaf/spline/proximity.py
+++ b/gustaf/spline/proximity.py
@@ -54,8 +54,8 @@ class Proximity:
 
     Examples
     ---------
-    >>> myspline = <your-spline>
-    >>> closest_cp_ids = myspline.proximity.closest_control_points(queries)
+    >>> my_spline = <your-spline>
+    >>> closest_cp_ids = my_spline.proximity.closest_control_points(queries)
     """
 
     def __init__(self, spl):

--- a/gustaf/spline/visualize.py
+++ b/gustaf/spline/visualize.py
@@ -134,7 +134,7 @@ def _vedo_showable(spline):
     )
     if data_name is not None and sampled_spline_data is not None:
         # transfer data
-        sampled_spline.vertexdata[data_name] = sampled_spline_data
+        sampled_spline.vertex_data[data_name] = sampled_spline_data
 
         # transfer options - maybe vectorized query?
         keys = ("vmin", "vmax", "scalarbar", "cmap", "cmapalpha")
@@ -196,7 +196,7 @@ def _vedo_showable(spline):
 
             # create vertices that can be shown as arrows
             loc_vertices = Vertices(spline.evaluate(queries), copy=False)
-            loc_vertices.vertexdata[adata_name] = adata
+            loc_vertices.vertex_data[adata_name] = adata
 
             # transfer options
             keys = ("arrow_data_scale", "arrow_data_color", "arrow_data")
@@ -208,7 +208,7 @@ def _vedo_showable(spline):
             gus_primitives["arrow_data"] = loc_vertices
 
         else:  # sample arrows and append to sampled spline.
-            sampled_spline.vertexdata[
+            sampled_spline.vertex_data[
                 adata_name
             ] = spline.spline_data.as_arrow(adata_name, resolutions=res)
             # transfer options

--- a/gustaf/spline/visualize.py
+++ b/gustaf/spline/visualize.py
@@ -129,12 +129,12 @@ def _vedo_showable(spline):
         spline.show_options.get("resolutions", 100), spline.para_dim
     )
     data_name = spline.show_options.get("data_name", None)
-    sampled_splinedata = spline.splinedata.as_scalar(
+    sampled_spline_data = spline.spline_data.as_scalar(
         data_name, res, default=None
     )
-    if data_name is not None and sampled_splinedata is not None:
+    if data_name is not None and sampled_spline_data is not None:
         # transfer data
-        sampled_spline.vertexdata[data_name] = sampled_splinedata
+        sampled_spline.vertexdata[data_name] = sampled_spline_data
 
         # transfer options - maybe vectorized query?
         keys = ("vmin", "vmax", "scalarbar", "cmap", "cmapalpha")
@@ -145,12 +145,12 @@ def _vedo_showable(spline):
         # mark that we want to see this data
         sampled_spline.show_options["data_name"] = data_name
 
-    elif data_name is not None and sampled_splinedata is None:
-        log.debug(f"No splinedata named ({data_name}) for {spline}. Skipping")
+    elif data_name is not None and sampled_spline_data is None:
+        log.debug(f"No spline_data named ({data_name}) for {spline}. Skipping")
 
     # with arrow representable, vector data
     adata_name = spline.show_options.get("arrow_data", None)
-    adapted_adata = spline.splinedata.get(adata_name, None)
+    adapted_adata = spline.spline_data.get(adata_name, None)
     if adata_name is not None and adapted_adata is not None:
         # if location is specified, this will be a separate Vertices obj with
         # configured arrow_data
@@ -192,7 +192,7 @@ def _vedo_showable(spline):
                 )
 
             # get arrow
-            adata = spline.splinedata.as_arrow(adata_name, on=on)
+            adata = spline.spline_data.as_arrow(adata_name, on=on)
 
             # create vertices that can be shown as arrows
             loc_vertices = Vertices(spline.evaluate(queries), copy=False)
@@ -208,9 +208,9 @@ def _vedo_showable(spline):
             gus_primitives["arrow_data"] = loc_vertices
 
         else:  # sample arrows and append to sampled spline.
-            sampled_spline.vertexdata[adata_name] = spline.splinedata.as_arrow(
-                adata_name, resolutions=res
-            )
+            sampled_spline.vertexdata[
+                adata_name
+            ] = spline.spline_data.as_arrow(adata_name, resolutions=res)
             # transfer options
             keys = ("arrow_data_scale", "arrow_data_color", "arrow_data")
             spline.show_options.copy_valid_options(

--- a/gustaf/spline/visualize.py
+++ b/gustaf/spline/visualize.py
@@ -62,8 +62,8 @@ class SplineShowOption(options.ShowOption):
         ),
         options.Option(
             "vedo",
-            "arrowdata_on",
-            "Specify parametric coordinates to place arrowdata.",
+            "arrow_data_on",
+            "Specify parametric coordinates to place arrow_data.",
             (list, tuple, np.ndarray),
         ),
     )
@@ -149,20 +149,20 @@ def _vedo_showable(spline):
         log.debug(f"No splinedata named ({data_name}) for {spline}. Skipping")
 
     # with arrow representable, vector data
-    adata_name = spline.show_options.get("arrowdata", None)
+    adata_name = spline.show_options.get("arrow_data", None)
     adapted_adata = spline.splinedata.get(adata_name, None)
     if adata_name is not None and adapted_adata is not None:
         # if location is specified, this will be a separate Vertices obj with
-        # configured arrowdata
+        # configured arrow_data
         has_locations = adapted_adata.has_locations
-        adata_on = "arrowdata_on" in spline.show_options.keys()
+        adata_on = "arrow_data_on" in spline.show_options.keys()
         create_vertices = has_locations or adata_on
 
         # this case causes conflict of interest. raise
         if has_locations and adata_on:
             raise ValueError(
-                f"arrowdata-({adata_name}) has fixed location, "
-                "but and `arrowdata_on` is set.",
+                f"arrow_data-({adata_name}) has fixed location, "
+                "but and `arrow_data_on` is set.",
             )
 
         if create_vertices:
@@ -171,14 +171,14 @@ def _vedo_showable(spline):
                 queries = adapted_adata.locations
                 on = None
             else:
-                queries = spline.show_options["arrowdata_on"]
+                queries = spline.show_options["arrow_data_on"]
                 on = queries
 
             # bound /  dim check
             bounds = spline.parametric_bounds
             if queries.shape[1] != len(bounds[0]):
                 raise ValueError(
-                    "Dimension mismatch: arrowdata locations-"
+                    "Dimension mismatch: arrow_data locations-"
                     f"{queries.shape[1]} / para_dim-{spline.para_dim}."
                 )
             # tolerance padding. may still cause issues in splinepy.
@@ -199,20 +199,20 @@ def _vedo_showable(spline):
             loc_vertices.vertexdata[adata_name] = adata
 
             # transfer options
-            keys = ("arrowdata_scale", "arrowdata_color", "arrowdata")
+            keys = ("arrow_data_scale", "arrow_data_color", "arrow_data")
             spline.show_options.copy_valid_options(
                 loc_vertices.show_options, keys
             )
 
             # add to primitives
-            gus_primitives["arrowdata"] = loc_vertices
+            gus_primitives["arrow_data"] = loc_vertices
 
         else:  # sample arrows and append to sampled spline.
             sampled_spline.vertexdata[adata_name] = spline.splinedata.as_arrow(
                 adata_name, resolutions=res
             )
             # transfer options
-            keys = ("arrowdata_scale", "arrowdata_color", "arrowdata")
+            keys = ("arrow_data_scale", "arrow_data_color", "arrow_data")
             spline.show_options.copy_valid_options(
                 sampled_spline.show_options, keys
             )

--- a/gustaf/spline/visualize.py
+++ b/gustaf/spline/visualize.py
@@ -137,7 +137,7 @@ def _vedo_showable(spline):
         sampled_spline.vertex_data[data_name] = sampled_spline_data
 
         # transfer options - maybe vectorized query?
-        keys = ("vmin", "vmax", "scalarbar", "cmap", "cmapalpha")
+        keys = ("vmin", "vmax", "scalarbar", "cmap", "cmap_alpha")
         spline.show_options.copy_valid_options(
             sampled_spline.show_options, keys
         )

--- a/gustaf/spline/visualize.py
+++ b/gustaf/spline/visualize.py
@@ -244,7 +244,7 @@ def _vedo_showable(spline):
         # pure control mesh
         c_mesh = spline.extract.control_mesh()  # either edges or faces
         if spline.para_dim != 1:
-            c_mesh = c_mesh.toedges(unique=True)
+            c_mesh = c_mesh.to_edges(unique=True)
 
         c_mesh.show_options["c"] = "red"
         c_mesh.show_options["lw"] = 4

--- a/gustaf/spline/visualize.py
+++ b/gustaf/spline/visualize.py
@@ -128,13 +128,13 @@ def _vedo_showable(spline):
     res = enforce_len(
         spline.show_options.get("resolutions", 100), spline.para_dim
     )
-    dataname = spline.show_options.get("dataname", None)
+    data_name = spline.show_options.get("data_name", None)
     sampled_splinedata = spline.splinedata.as_scalar(
-        dataname, res, default=None
+        data_name, res, default=None
     )
-    if dataname is not None and sampled_splinedata is not None:
+    if data_name is not None and sampled_splinedata is not None:
         # transfer data
-        sampled_spline.vertexdata[dataname] = sampled_splinedata
+        sampled_spline.vertexdata[data_name] = sampled_splinedata
 
         # transfer options - maybe vectorized query?
         keys = ("vmin", "vmax", "scalarbar", "cmap", "cmapalpha")
@@ -143,10 +143,10 @@ def _vedo_showable(spline):
         )
 
         # mark that we want to see this data
-        sampled_spline.show_options["dataname"] = dataname
+        sampled_spline.show_options["data_name"] = data_name
 
-    elif dataname is not None and sampled_splinedata is None:
-        log.debug(f"No splinedata named ({dataname}) for {spline}. Skipping")
+    elif data_name is not None and sampled_splinedata is None:
+        log.debug(f"No splinedata named ({data_name}) for {spline}. Skipping")
 
     # with arrow representable, vector data
     adata_name = spline.show_options.get("arrowdata", None)

--- a/gustaf/spline/visualize.py
+++ b/gustaf/spline/visualize.py
@@ -94,7 +94,7 @@ def make_showable(spline):
 
 def _vedo_showable(spline):
     """
-    Goes through common precedures for preparing showable splines.
+    Goes through common procedures for preparing showable splines.
 
     Parameters
     ----------
@@ -242,17 +242,17 @@ def _vedo_showable(spline):
 
     if spline.show_options.get("control_mesh", show_cps):
         # pure control mesh
-        cmesh = spline.extract.control_mesh()  # either edges or faces
+        c_mesh = spline.extract.control_mesh()  # either edges or faces
         if spline.para_dim != 1:
-            cmesh = cmesh.toedges(unique=True)
+            c_mesh = c_mesh.toedges(unique=True)
 
-        cmesh.show_options["c"] = "red"
-        cmesh.show_options["lw"] = 4
-        cmesh.show_options["alpha"] = spline.show_options.get(
+        c_mesh.show_options["c"] = "red"
+        c_mesh.show_options["lw"] = 4
+        c_mesh.show_options["alpha"] = spline.show_options.get(
             "control_points_alpha", 0.8
         )
         # add
-        gus_primitives["control_mesh"] = cmesh
+        gus_primitives["control_mesh"] = c_mesh
 
     # fitting queries
     if hasattr(spline, "_fitting_queries") and spline.show_options.get(
@@ -267,8 +267,7 @@ def _vedo_showable(spline):
 
 
 def _vedo_showable_para_dim_1(spline):
-    """
-    Assumes showability check has been already performed
+    """Assumes showability check has been already performed.
 
     Parameters
     ----------

--- a/gustaf/utils/arr.py
+++ b/gustaf/utils/arr.py
@@ -148,7 +148,7 @@ def close_rows(arr, tolerance=None):
     if tolerance is None:
         tolerance = settings.TOLERANCE
 
-    # Build kdtree
+    # Build kd tree
     kdt = KDTree(arr)
 
     # Ball point query, taking tolerance as radius
@@ -340,11 +340,13 @@ def rotate(arr, rotation, rotation_axis=None, degree=True):
         return np.matmul(arr, rotation_matrix(rotation, degree))
 
     else:
-        rarr = arr - rotation_axis
-        rarr = np.matmul(rarr, rotation_matrix(rotation, degree))
-        rarr += rotation_axis
+        shifted_array = arr - rotation_axis
+        shifted_array = np.matmul(
+            shifted_array, rotation_matrix(rotation, degree)
+        )
+        shifted_array += rotation_axis
 
-        return rarr
+        return shifted_array
 
 
 def rotation_matrix_around_axis(axis=None, rotation=None, degree=True):

--- a/gustaf/utils/arr.py
+++ b/gustaf/utils/arr.py
@@ -340,13 +340,13 @@ def rotate(arr, rotation, rotation_axis=None, degree=True):
         return np.matmul(arr, rotation_matrix(rotation, degree))
 
     else:
-        shifted_array = arr - rotation_axis
-        shifted_array = np.matmul(
-            shifted_array, rotation_matrix(rotation, degree)
+        rotated_array = arr - rotation_axis
+        rotated_array = np.matmul(
+            rotated_array, rotation_matrix(rotation, degree)
         )
-        shifted_array += rotation_axis
+        rotated_array += rotation_axis
 
-        return shifted_array
+        return rotated_array
 
 
 def rotation_matrix_around_axis(axis=None, rotation=None, degree=True):

--- a/gustaf/utils/connec.py
+++ b/gustaf/utils/connec.py
@@ -236,7 +236,7 @@ def range_to_edges(range_, closed=False, continuous=True):
             raise ValueError("Ranges should result in even number of indices.")
         return indices.reshape(-1, 2)
 
-    # continous edges
+    # continuous edges
     indices = np.repeat(indices, 2)
     if closed:
         indices = np.append(indices, indices[0])[1:]
@@ -399,7 +399,7 @@ def subdivide_edges(edges):
 
     Returns
     --------
-    subd_edges: (n * 2, 2) np.ndarray
+    subdivided_edges: (n * 2, 2) np.ndarray
     """
     if edges.ndim != 2 or edges.shape[1] != 2:
         raise ValueError("Invalid edges shape!")
@@ -445,10 +445,10 @@ def subdivide_tri(
     Returns
     --------
     new_vertices: (n, d) np.ndarray
-    subd_faces: (m, 3) np.ndarray
+    subdivided_faces: (m, 3) np.ndarray
     mesh_dict: dict
       iff `return_dict=True`,
-      returns dict(vertices=new_vertices, faces=subd_faces).
+      returns dict(vertices=new_vertices, faces=subdivided_faces).
     """
     # This will only pass if the mesh is triangle mesh.
     if mesh.faces.shape[1] != 3:
@@ -458,36 +458,36 @@ def subdivide_tri(
     edge_mid_v = mesh.vertices[mesh.unique_edges().values].mean(axis=1)
     new_vertices = np.vstack((mesh.vertices, edge_mid_v))
 
-    subd_faces = np.empty(
+    subdivided_faces = np.empty(
         (mesh.faces.shape[0] * 4, mesh.faces.shape[1]),
         dtype=np.int32,
     )
 
-    mask = np.ones(subd_faces.shape[0], dtype=bool)
+    mask = np.ones(subdivided_faces.shape[0], dtype=bool)
     mask[3::4] = False
 
     # 0th column minus (every 4th row, starting from 3rd row)
-    subd_faces[mask, 0] = mesh.faces.flatten()  # copies
+    subdivided_faces[mask, 0] = mesh.faces.flatten()  # copies
 
     # Form ids for new vertices
     new_vertices_ids = mesh.unique_edges().inverse + int(mesh.faces.max() + 1)
     # 1st & 2nd columns
-    subd_faces[mask, 1] = new_vertices_ids
-    subd_faces[mask, 2] = new_vertices_ids.reshape(-1, 3)[
+    subdivided_faces[mask, 1] = new_vertices_ids
+    subdivided_faces[mask, 2] = new_vertices_ids.reshape(-1, 3)[
         :, [2, 0, 1]
     ].flatten()
 
     # Every 4th row, starting from 3rd row
-    subd_faces[~mask, :] = new_vertices_ids.reshape(-1, 3)
+    subdivided_faces[~mask, :] = new_vertices_ids.reshape(-1, 3)
 
     if return_dict:
         return dict(
             vertices=new_vertices,
-            faces=subd_faces,
+            faces=subdivided_faces,
         )
 
     else:
-        return new_vertices, subd_faces
+        return new_vertices, subdivided_faces
 
 
 def subdivide_quad(
@@ -504,10 +504,10 @@ def subdivide_quad(
     Returns
     --------
     new_vertices: (n, d) np.ndarray
-    subd_faces: (m, 4) np.ndarray
+    subdivided_faces: (m, 4) np.ndarray
     mesh_dict: dict
       iff `return_dict=True`,
-      returns dict(vertices=new_vertices, faces=subd_faces).
+      returns dict(vertices=new_vertices, faces=subdivided_faces).
     """
     # This will only pass if the mesh is quad mesh.
     if mesh.faces.shape[1] != 4:
@@ -524,30 +524,30 @@ def subdivide_quad(
         )
     )
 
-    subd_faces = np.empty(
+    subdivided_faces = np.empty(
         (mesh.faces.shape[0] * 4, mesh.faces.shape[1]),
         dtype=np.int32,
     )
 
-    subd_faces[:, 0] = mesh.faces.flatten()
-    subd_faces[:, 1] = mesh.unique_edges().inverse + len(mesh.vertices)
-    subd_faces[:, 2] = np.repeat(
+    subdivided_faces[:, 0] = mesh.faces.flatten()
+    subdivided_faces[:, 1] = mesh.unique_edges().inverse + len(mesh.vertices)
+    subdivided_faces[:, 2] = np.repeat(
         np.arange(len(face_centers)) + (len(mesh.vertices) + len(edge_mid_v)),
         4,
         # dtype=np.int32,
     )
-    subd_faces[:, 3] = (
-        subd_faces[:, 1].reshape(-1, 4)[:, [3, 0, 1, 2]].flatten()
+    subdivided_faces[:, 3] = (
+        subdivided_faces[:, 1].reshape(-1, 4)[:, [3, 0, 1, 2]].flatten()
     )
 
     if return_dict:
         return dict(
             vertices=new_vertices,
-            faces=subd_faces,
+            faces=subdivided_faces,
         )
 
     else:
-        return new_vertices, subd_faces
+        return new_vertices, subdivided_faces
 
 
 def sorted_unique(connectivity, sorted_=False):

--- a/gustaf/utils/log.py
+++ b/gustaf/utils/log.py
@@ -107,7 +107,7 @@ def prepended_log(message, log_func):
 
     Parameters
     ----------
-    messgae: str
+    message: str
     log_func: function
       one of the followings - {info, debug, warning}
 

--- a/gustaf/utils/tictoc.py
+++ b/gustaf/utils/tictoc.py
@@ -87,7 +87,7 @@ class Tic(GustafBase):
            times for each lap from the timer start (cumulative time).
         """
         start = self._laps[0]
-        cummulative = [f"{lap-start:.10f}" for lap in self._laps[1:]]
+        cumulative = [f"{lap-start:.10f}" for lap in self._laps[1:]]
 
         if log or print_:
             message = [f"\n+++ {self._title} - time logs +++\n"]
@@ -100,19 +100,19 @@ class Tic(GustafBase):
                 for l0, l1 in zip(self._laps[:-1], self._laps[1:])
             ]
             diff_width = int(max([len(d) for d in diff]))
-            cumm_width = int(max([len(c) for c in cummulative]))
+            cumulative_width = int(max([len(c) for c in cumulative]))
 
             message.append(
                 f"{'names'.ljust(name_width)} | "
                 f"{'diff'.rjust(diff_width)} | "
-                f"{'cummulative'.rjust(cumm_width)}\n"
+                f"{'cumulative'.rjust(cumulative_width)}\n"
             )
 
-            for n, d, c in zip(self._names, diff, cummulative):
+            for n, d, c in zip(self._names, diff, cumulative):
                 this_line = (
                     f"{n.ljust(name_width)} | "
                     f"{d.rjust(diff_width)} | "
-                    f"{c.rjust(cumm_width)}\n"
+                    f"{c.rjust(cumulative_width)}\n"
                 )
                 message.append(this_line)
 
@@ -121,4 +121,4 @@ class Tic(GustafBase):
             if print_:
                 print(*message)
 
-        return self._names.copy(), cummulative
+        return self._names.copy(), cumulative

--- a/gustaf/vertices.py
+++ b/gustaf/vertices.py
@@ -94,7 +94,7 @@ class Vertices(GustafBase):
         "_vertex_data",
     )
 
-    # define freuqently used types as dunder variable
+    # define frequently used types as dunder variable
     __show_option__ = VerticesShowOption
 
     def __init__(
@@ -345,7 +345,7 @@ class Vertices(GustafBase):
 
         Returns
         --------
-        bounds_digonal: (d,) np.ndarray
+        bounds_diagonal: (d,) np.ndarray
           same as `bounds[1] - bounds[0]`
         """
         self._logd("computing bounds_diagonal")
@@ -411,23 +411,23 @@ class Vertices(GustafBase):
             )
             # remove all the elements that's not part of inverse
             if check_neg:
-                emask = (elements > -1).all(axis=1)
-                elements = elements[emask]
+                elem_mask = (elements > -1).all(axis=1)
+                elements = elements[elem_mask]
 
         # apply mask
         vertices = vertices[mask]
 
         def update_vertex_data(obj, m, vertex_data=None):
             """apply mask to vertex data if there's any."""
-            newdata = helpers.data.VertexData(obj)
+            new_data = helpers.data.VertexData(obj)
             if vertex_data is None:
                 vertex_data = obj.vertex_data
 
             for key, values in vertex_data.items():
                 # should work, since this is called after updating vertices
-                newdata[key] = values[m]
+                new_data[key] = values[m]
 
-            obj._vertex_data = newdata
+            obj._vertex_data = new_data
 
             return obj
 
@@ -530,7 +530,7 @@ class Vertices(GustafBase):
 
         Returns
         --------
-        selfcopy: type(self)
+        self_copy: type(self)
         """
         # all attributes are deepcopy-able
         return copy.deepcopy(self)
@@ -566,8 +566,8 @@ class Vertices(GustafBase):
             instances = instances[0]
 
         vertices = []
-        haselem = cls.kind != "vertex"
-        if haselem:
+        has_elem = cls.kind != "vertex"
+        if has_elem:
             elements = []
 
         # check if everything is "concatable".
@@ -583,7 +583,7 @@ class Vertices(GustafBase):
 
             vertices.append(tmp_ins.vertices.copy())
 
-            if haselem:
+            if has_elem:
                 if len(elements) == 0:
                     elements.append(tmp_ins.elements.copy())
                     e_offset = elements[-1].max() + 1
@@ -596,7 +596,7 @@ class Vertices(GustafBase):
                     )
                     e_offset = elements[-1].max() + 1
 
-        if haselem:
+        if has_elem:
             return cls(
                 vertices=np.vstack(vertices),
                 elements=np.vstack(elements),

--- a/gustaf/vertices.py
+++ b/gustaf/vertices.py
@@ -91,7 +91,7 @@ class Vertices(GustafBase):
         "_computed",
         "_show_options",
         "_setter_copies",
-        "_vertexdata",
+        "_vertex_data",
     )
 
     # define freuqently used types as dunder variable
@@ -119,7 +119,7 @@ class Vertices(GustafBase):
         self.vertices = vertices
 
         # init helpers
-        self._vertexdata = helpers.data.VertexData(self)
+        self._vertex_data = helpers.data.VertexData(self)
         self._computed = helpers.data.ComputedMeshData(self)
         self._show_options = self.__show_option__(self)
 
@@ -168,10 +168,10 @@ class Vertices(GustafBase):
         self._const_vertices = self._vertices.view()
         self._const_vertices.flags.writeable = False
 
-        # at each setting, validate vertexdata
+        # at each setting, validate vertex_data
         # --> by len mismatch, will clear data
-        if hasattr(self, "vertexdata"):
-            self.vertexdata._validate_len(raise_=False)
+        if hasattr(self, "vertex_data"):
+            self.vertex_data._validate_len(raise_=False)
 
     @property
     def const_vertices(self):
@@ -190,9 +190,9 @@ class Vertices(GustafBase):
         return self._const_vertices
 
     @property
-    def vertexdata(self):
+    def vertex_data(self):
         """
-        Returns vertexdata manager. Behaves similar to dict() and can be used
+        Returns vertex_data manager. Behaves similar to dict() and can be used
         to store values/data associated with each vertex.
 
         Parameters
@@ -201,10 +201,10 @@ class Vertices(GustafBase):
 
         Returns
         -------
-        vertexdata: VertexData
+        vertex_data: VertexData
         """
-        self._logd("returning vertexdata")
-        return self._vertexdata
+        self._logd("returning vertex_data")
+        return self._vertex_data
 
     @property
     def setter_copies(self):
@@ -417,17 +417,17 @@ class Vertices(GustafBase):
         # apply mask
         vertices = vertices[mask]
 
-        def update_vertexdata(obj, m, vertex_data=None):
+        def update_vertex_data(obj, m, vertex_data=None):
             """apply mask to vertex data if there's any."""
             newdata = helpers.data.VertexData(obj)
             if vertex_data is None:
-                vertex_data = obj.vertexdata
+                vertex_data = obj.vertex_data
 
             for key, values in vertex_data.items():
                 # should work, since this is called after updating vertices
                 newdata[key] = values[m]
 
-            obj._vertexdata = newdata
+            obj._vertex_data = newdata
 
             return obj
 
@@ -436,7 +436,7 @@ class Vertices(GustafBase):
         if elements is not None:
             self.elements = elements
 
-        update_vertexdata(self, mask)
+        update_vertex_data(self, mask)
 
         return self
 

--- a/gustaf/volumes.py
+++ b/gustaf/volumes.py
@@ -46,20 +46,20 @@ class VolumesShowOption(helpers.options.ShowOption):
 
             to_vtktype = {"tet": frau_tetra, "hexa": herr_hexa}
             grid_type = to_vtktype[self._helpee.whatami]
-            ugrid = show.vedo.UGrid(
+            u_grid = show.vedo.UGrid(
                 [
                     self._helpee.const_vertices,
                     self._helpee.const_volumes,
                     [grid_type] * len(self._helpee.const_volumes),
                 ]
             )
-            return ugrid.c("hotpink")
+            return u_grid.c("hotpink")
 
         # to show data, let's use Faces. This will plot all the elements
         # as well as invisible ones. This will at least try to avoid
         # duplicating faces.  If you wanna see inside faces, try
-        # as_shrinked_faces = volumes.tofaces(unique=False).shrink(.8)
-        faces = self._helpee.tofaces(unique=True)
+        # as_shrunk_faces = volumes.to_faces(unique=False).shrink(.8)
+        faces = self._helpee.to_faces(unique=True)
         self.copy_valid_options(faces.show_options)
 
         return faces.show_options._initialize_vedo_showable()
@@ -240,7 +240,7 @@ class Volumes(Faces):
         Returns
         --------
         unique_info: Unique2DIntegers
-          valid attribut4es are {values, ids, inverse, counts}
+          valid attributes are {values, ids, inverse, counts}
         """
         unique_info = utils.connec.sorted_unique(
             self.sorted_volumes(),
@@ -257,7 +257,7 @@ class Volumes(Faces):
         """Alias to update_elements."""
         self.update_elements(*args, **kwargs)
 
-    def tofaces(self, unique=True):
+    def to_faces(self, unique=True):
         """Returns Faces obj.
 
         Parameters

--- a/gustaf/volumes.py
+++ b/gustaf/volumes.py
@@ -37,7 +37,7 @@ class VolumesShowOption(helpers.options.ShowOption):
         # without a data to plot on the surface, return vedo.UGrid
         # if vertex_ids is on, we will go with mesh
         if (
-            self.get("dataname", None) is None
+            self.get("data_name", None) is None
             and not self.get("vertex_ids", False)
             and not self.get("arrowdata", False)
         ):

--- a/gustaf/volumes.py
+++ b/gustaf/volumes.py
@@ -39,7 +39,7 @@ class VolumesShowOption(helpers.options.ShowOption):
         if (
             self.get("data_name", None) is None
             and not self.get("vertex_ids", False)
-            and not self.get("arrowdata", False)
+            and not self.get("arrow_data", False)
         ):
             from vtk import VTK_HEXAHEDRON as herr_hexa
             from vtk import VTK_TETRA as frau_tetra

--- a/tests/test_basic_calls.py
+++ b/tests/test_basic_calls.py
@@ -50,7 +50,7 @@ class BasicCallsTest(unittest.TestCase):
         es.referenced_vertices()
         es.dashed()
         es.shrink()
-        es.tovertices()
+        es.to_vertices()
         es.single_edges()
         es.remove_unreferenced_vertices()
 
@@ -73,7 +73,7 @@ class BasicCallsTest(unittest.TestCase):
             fs.centers()
             fs.referenced_vertices()
             fs.shrink()
-            fs.tovertices()
+            fs.to_vertices()
             fs.remove_unreferenced_vertices()
 
             # fs.update_faces()
@@ -87,7 +87,7 @@ class BasicCallsTest(unittest.TestCase):
             vs.const_volumes
             vs.sorted_volumes()
             vs.unique_volumes()
-            vs.tofaces()
+            vs.to_faces()
 
             vs.sorted_edges()
             vs.unique_edges()
@@ -95,7 +95,7 @@ class BasicCallsTest(unittest.TestCase):
             vs.centers()
             vs.referenced_vertices()
             vs.shrink()
-            vs.tovertices()
+            vs.to_vertices()
             vs.remove_unreferenced_vertices()
 
             vs.sorted_faces()


### PR DESCRIPTION
Multiple smallish commits fixing some spelling and style guide issues.

This is now more in line to follow the pep8 style guide. 

In reference to #105 