### PR TITLE
Concat nocopy

### DIFF
--- a/gustaf/vertices.py
+++ b/gustaf/vertices.py
@@ -581,16 +581,15 @@ class Vertices(GustafBase):
             # make sure each element index starts from 0 & end at len(vertices)
             tmp_ins = ins.copy().remove_unreferenced_vertices()
 
-            vertices.append(tmp_ins.vertices.copy())
+            vertices.append(tmp_ins.vertices)
 
             if has_elem:
                 if len(elements) == 0:
-                    elements.append(tmp_ins.elements.copy())
+                    elements.append(tmp_ins.elements)
                     e_offset = elements[-1].max() + 1
 
                 else:
                     elements.append(
-                        # copy is not necessary here,
                         tmp_ins.elements
                         + e_offset
                     )

--- a/gustaf/vertices.py
+++ b/gustaf/vertices.py
@@ -578,8 +578,11 @@ class Vertices(GustafBase):
                     f"`{cls.__name__}`."
                 )
 
+            tmp_ins = ins.copy()
+
             # make sure each element index starts from 0 & end at len(vertices)
-            tmp_ins = ins.copy().remove_unreferenced_vertices()
+            if has_elem:
+                tmp_ins.remove_unreferenced_vertices()
 
             vertices.append(tmp_ins.vertices)
 
@@ -589,10 +592,7 @@ class Vertices(GustafBase):
                     e_offset = elements[-1].max() + 1
 
                 else:
-                    elements.append(
-                        tmp_ins.elements
-                        + e_offset
-                    )
+                    elements.append(tmp_ins.elements + e_offset)
                     e_offset = elements[-1].max() + 1
 
         if has_elem:

--- a/tests/test_concat.py
+++ b/tests/test_concat.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pytest
+
+# frequently used fixtures
+all_grids = (
+    "vertices",
+    "edges",
+    "faces_tri",
+    "faces_quad",
+    "volumes_tet",
+    "volumes_hexa",
+)
+
+
+@pytest.mark.parametrize("grid", all_grids)
+def test_concat(grid, request):
+    """Test concat. uses merge_vertices to double check."""
+    grid = request.getfixturevalue(grid)
+
+    n_grids = 5
+
+    n_vertices = len(grid.vertices)
+
+    if grid.kind != "vertex":
+        n_elements = len(grid.elements)
+
+    grids = [grid for _ in range(n_grids)]
+
+    concated = type(grid).concat(*grids)
+
+    # check concatenated vertices
+    assert np.allclose(np.tile(grid.vertices, (n_grids, 1)), concated.vertices)
+
+    # check number of concatenated elements
+    if grid.kind != "vertex":
+        assert int(n_elements * n_grids) == len(concated.elements)
+        assert int(n_vertices * n_grids - 1) == concated.elements.max()
+
+    # merge vertices, then this should only have n_vertices left
+    concated.merge_vertices()
+    assert np.allclose(grid.vertices, concated.vertices)
+
+    # as well as n_elements * n_grids, but elements just repeats n_grids times
+    if grid.kind != "vertex":
+        assert (
+            np.tile(grid.elements, (n_grids, 1)) - concated.elements
+        ).sum() == 0


### PR DESCRIPTION
Avoid unnecessary double-copy in concat. Adds test.