### PR TITLE
call merge_vertices after sampling data

### DIFF
--- a/gustaf/helpers/data.py
+++ b/gustaf/helpers/data.py
@@ -467,6 +467,7 @@ class VertexData(DataHolder):
             return valid
 
         # here, check all saved values.
+        to_pop = []
         for key, value in self._saved.items():
             if len(value) != helpee_len:
                 valid = False
@@ -480,11 +481,15 @@ class VertexData(DataHolder):
                 else:
                     self._logd(
                         f"`{key}`-data len ({len(value)}) doesn't match "
-                        f"expect len ({helpee_len}). Deleting `{key}`."
+                        f"expected len ({helpee_len}). Deleting `{key}`."
                     )
                 # pop invalid data
-                self._saved.pop(key)
-                self._saved.pop(key + "__norm", None)
+                to_pop.append(key)
+                to_pop.append(key + "__norm")
+
+        # pop if needed
+        for tp in to_pop:
+            self._saved.pop(tp, None)
 
         return valid
 
@@ -712,7 +717,9 @@ class SplineDataAdaptor(GustafBase):
                 return self.function(self.data, resolutions=resolutions)
             elif self.is_spline and self.data.para_dim > 2:
                 # TODO: replace this with generalized query helpers.
-                return self.data.extract.faces(resolutions).vertices
+                return self.data.extract.faces(
+                    resolutions, watertight=False
+                ).vertices
             else:
                 return self.data.sample(resolutions)
 

--- a/gustaf/spline/extract.py
+++ b/gustaf/spline/extract.py
@@ -113,6 +113,7 @@ def edges(
 def faces(
     spline,
     resolutions,
+    watertight=True,
 ):
     """Extract faces from spline. Valid iff para_dim is one of the followings:
     {2, 3}. In case of {3}, it will return only surfaces. If internal faces are
@@ -123,6 +124,9 @@ def faces(
     -----------
     spline: BSpline or NURBS
     resolutions: int or list
+    watertight: bool
+      Default is True. Only related to para_dim = 3 splines. If False,
+      overlapping vertices at boundary edges won't be merged.
 
     Returns
     --------
@@ -240,7 +244,9 @@ def faces(
 
         # make faces and merge vertices before returning
         f = Faces(vertices=np.vstack(vertices), faces=np.vstack(faces))
-        f.merge_vertices()
+
+        if watertight:
+            f.merge_vertices()
 
         return f
 

--- a/gustaf/spline/visualize.py
+++ b/gustaf/spline/visualize.py
@@ -218,7 +218,8 @@ def _vedo_showable(spline):
             )
 
     # double check on same obj ref
-    gus_primitives["spline"] = sampled_spline
+    # merge vertices here, so that we return a watertight mesh
+    gus_primitives["spline"] = sampled_spline.merge_vertices()
 
     # control_points & control_points_alpha
     show_cps = spline.show_options.get("control_points", True)
@@ -320,7 +321,7 @@ def _vedo_showable_para_dim_2(spline):
     res = enforce_len(
         spline.show_options.get("resolutions", 100), spline.para_dim
     )
-    sp = spline.extract.faces(res)
+    sp = spline.extract.faces(res, watertight=False)  # always watertight
     gus_primitives["spline"] = sp
 
     # knots
@@ -337,4 +338,6 @@ def _vedo_showable_para_dim_3(spline):
     """
     Currently same as _vedo_showable_para_dim_2
     """
+    # we keep the watertight to False, since we may wanna plot some data with
+    # same values. (issue #120)
     return _vedo_showable_para_dim_2(spline)

--- a/gustaf/vertices.py
+++ b/gustaf/vertices.py
@@ -417,11 +417,9 @@ class Vertices(GustafBase):
         # apply mask
         vertices = vertices[mask]
 
-        def update_vertex_data(obj, m, vertex_data=None):
+        def update_vertex_data(obj, m, vertex_data):
             """apply mask to vertex data if there's any."""
             new_data = helpers.data.VertexData(obj)
-            if vertex_data is None:
-                vertex_data = obj.vertex_data
 
             for key, values in vertex_data.items():
                 # should work, since this is called after updating vertices
@@ -431,12 +429,16 @@ class Vertices(GustafBase):
 
             return obj
 
-        # update
+        # make shallow copy of saved vertex data
+        v_data = self.vertex_data._saved.copy()
+
+        # update - if number of vertices changes, this will remove all the
+        #   length mis-matching data.
         self.vertices = vertices
         if elements is not None:
             self.elements = elements
 
-        update_vertex_data(self, mask)
+        update_vertex_data(self, mask, v_data)
 
         return self
 


### PR DESCRIPTION
fixes #120.  

## cause
for volumes (para_dim = 3), to make sure data is sampled at the same place as the geometry, `data_spline.extract.faces(resolutions)` was used. That call always merges vertices, so if data has recurring values, it would merge them. 