### PR TITLE
Improvement to io.meshio.load 

### DIFF
--- a/examples/show_gmsh.py
+++ b/examples/show_gmsh.py
@@ -7,11 +7,12 @@ import pathlib
 
 import load_sample_file
 
-from gustaf import io
+from gustaf import Vertices, io, show
 
 if __name__ == "__main__":
     mesh_file_tri = pathlib.Path("faces/tri/2DChannelTria.msh")
     mesh_file_quad = pathlib.Path("faces/quad/2DChannelQuad.msh")
+    mesh_file_tetra = pathlib.Path("faces/tetra/3DBrickTetra.msh")
 
     base_samples_path = pathlib.Path("samples")
     if not base_samples_path.exists():
@@ -33,3 +34,30 @@ if __name__ == "__main__":
     loaded_mesh_default = io.load(base_samples_path / mesh_file_tri)
 
     loaded_mesh_default.show()
+
+    loaded_meshes = io.load(
+        base_samples_path / mesh_file_tri,
+        return_only_one_mesh=False,
+        set_boundary=True,
+    )
+    boundary_node_indices = loaded_meshes[0].BC["edges-nodes"]
+    boundary_vertices = Vertices(
+        loaded_meshes[0].vertices[boundary_node_indices]
+    )
+
+    show.show_vedo(
+        ["faces", loaded_meshes[0]],
+        ["boundaries: edges", loaded_meshes[1]],
+        ["vertices", boundary_vertices],
+    )
+
+    rect_meshes = io.load(
+        base_samples_path / mesh_file_tetra, return_only_one_mesh=False
+    )
+
+    show.show_vedo(
+        *[
+            [name, mesh]
+            for name, mesh in zip(["volume", "face", "line"], rect_meshes)
+        ]
+    )

--- a/examples/show_gmsh.py
+++ b/examples/show_gmsh.py
@@ -15,11 +15,9 @@ if __name__ == "__main__":
     mesh_file_tetra = pathlib.Path("volumes/tetra/3DBrickTetra.msh")
 
     base_samples_path = pathlib.Path("samples")
-    load_sample_file.load_sample_file(mesh_file_tri)
-    load_sample_file.load_sample_file(mesh_file_quad)
-    load_sample_file.load_sample_file(mesh_file_tetra) 
-        load_sample_file.load_sample_file(str(mesh_file_tri))
-        load_sample_file.load_sample_file(str(mesh_file_quad))
+    load_sample_file.load_sample_file(str(mesh_file_tri))
+    load_sample_file.load_sample_file(str(mesh_file_quad))
+    load_sample_file.load_sample_file(str(mesh_file_tetra))
 
     # load the .msh file directly with the correct io module (meshio)
     loaded_mesh_tri = io.meshio.load(base_samples_path / mesh_file_tri)

--- a/examples/show_gmsh.py
+++ b/examples/show_gmsh.py
@@ -15,7 +15,9 @@ if __name__ == "__main__":
     mesh_file_tetra = pathlib.Path("volumes/tetra/3DBrickTetra.msh")
 
     base_samples_path = pathlib.Path("samples")
-    if not base_samples_path.exists():
+    load_sample_file.load_sample_file(mesh_file_tri)
+    load_sample_file.load_sample_file(mesh_file_quad)
+    load_sample_file.load_sample_file(mesh_file_tetra) 
         load_sample_file.load_sample_file(str(mesh_file_tri))
         load_sample_file.load_sample_file(str(mesh_file_quad))
 

--- a/examples/show_gmsh.py
+++ b/examples/show_gmsh.py
@@ -12,7 +12,7 @@ from gustaf import Vertices, io, show
 if __name__ == "__main__":
     mesh_file_tri = pathlib.Path("faces/tri/2DChannelTria.msh")
     mesh_file_quad = pathlib.Path("faces/quad/2DChannelQuad.msh")
-    mesh_file_tetra = pathlib.Path("volumes/tetra/3DBrickTetra.msh")
+    mesh_file_tetra = pathlib.Path("volumes/tet/3DBrickTetra.msh")
 
     base_samples_path = pathlib.Path("samples")
     load_sample_file.load_sample_file(str(mesh_file_tri))

--- a/examples/show_gmsh.py
+++ b/examples/show_gmsh.py
@@ -12,7 +12,7 @@ from gustaf import Vertices, io, show
 if __name__ == "__main__":
     mesh_file_tri = pathlib.Path("faces/tri/2DChannelTria.msh")
     mesh_file_quad = pathlib.Path("faces/quad/2DChannelQuad.msh")
-    mesh_file_tetra = pathlib.Path("faces/tetra/3DBrickTetra.msh")
+    mesh_file_tetra = pathlib.Path("volumes/tetra/3DBrickTetra.msh")
 
     base_samples_path = pathlib.Path("samples")
     if not base_samples_path.exists():
@@ -52,7 +52,9 @@ if __name__ == "__main__":
     )
 
     rect_meshes = io.load(
-        base_samples_path / mesh_file_tetra, return_only_one_mesh=False
+        base_samples_path / mesh_file_tetra,
+        return_only_one_mesh=False,
+        set_boundary=True,
     )
 
     show.show_vedo(
@@ -60,4 +62,16 @@ if __name__ == "__main__":
             [name, mesh]
             for name, mesh in zip(["volume", "face", "line"], rect_meshes)
         ]
+    )
+
+    volume_nodes = Vertices(
+        rect_meshes[0].vertices[rect_meshes[0].BC["tri-nodes"]]
+    )
+    faces_nodes = Vertices(
+        rect_meshes[0].vertices[rect_meshes[1].BC["edges-nodes"]]
+    )
+
+    show.show_vedo(
+        ["volumes: boundary-nodes", rect_meshes[0], volume_nodes],
+        ["faces: boundary-nodes", rect_meshes[1], faces_nodes],
     )

--- a/examples/show_gmsh.py
+++ b/examples/show_gmsh.py
@@ -12,7 +12,7 @@ from gustaf import Vertices, io, show
 if __name__ == "__main__":
     mesh_file_tri = pathlib.Path("faces/tri/2DChannelTria.msh")
     mesh_file_quad = pathlib.Path("faces/quad/2DChannelQuad.msh")
-    mesh_file_tetra = pathlib.Path("volumes/tet/3DBrickTetra.msh")
+    mesh_file_tetra = pathlib.Path("volumes/tet/3DBrickTet.msh")
 
     base_samples_path = pathlib.Path("samples")
     load_sample_file.load_sample_file(str(mesh_file_tri))

--- a/gustaf/io/default.py
+++ b/gustaf/io/default.py
@@ -3,7 +3,7 @@ import pathlib
 from gustaf.io import meshio, mfem, mixd
 
 
-def load(fname):
+def load(fname, **kwargs):
     """Load function for all supported file formats.
 
     This function tries to guess the correct io module for the given file.
@@ -27,7 +27,7 @@ def load(fname):
     fname = pathlib.Path(fname).resolve()
 
     if fname.suffix in extensions_to_load_functions:
-        return extensions_to_load_functions[fname.suffix](fname)
+        return extensions_to_load_functions[fname.suffix](fname, **kwargs)
 
     else:
         raise ValueError(

--- a/gustaf/io/meshio.py
+++ b/gustaf/io/meshio.py
@@ -87,7 +87,6 @@ def load(fname, set_boundary=False, return_only_one_mesh=True):
                 f"Sorry, {elem_type} elements currently are not supported."
             )
 
-    set_boundary = True
     if set_boundary is True:
         # mesh.BC is only defined for volumes and faces
         for i in range(len(meshes)):

--- a/gustaf/io/meshio.py
+++ b/gustaf/io/meshio.py
@@ -43,7 +43,7 @@ def load(fname, set_boundary=False, return_only_one_mesh=True):
     return_only_one_mesh : bool, optional, default is True
         Return only the highest-dimensional mesh, ensures compartibility.
 
-    Returns,
+    Returns
     --------
     MESH_TYPES or list(MESH_TYPES)
     """

--- a/gustaf/io/meshio.py
+++ b/gustaf/io/meshio.py
@@ -93,6 +93,12 @@ def load(fname, set_boundary=False, return_only_one_mesh=True):
         for i in range(len(meshes)):
             # Indicator for boundary
             if meshes[i][1] in [3, 2]:
+                for field_key, field_cell in meshio_mesh.field_data.items():
+                    if field_cell[1] == meshes[i][1] - 1:
+                        meshes[i][0].BC[field_key] = np.unique(
+                            meshio_mesh.cells[field_cell[0]].data
+                        )
+
                 for j in range(i, len(meshes)):
                     # Considers only (d-1)-dimensional subspaces
                     if meshes[j][1] == meshes[i][1] - 1:

--- a/gustaf/io/meshio.py
+++ b/gustaf/io/meshio.py
@@ -7,6 +7,7 @@ import pathlib
 
 import numpy as np
 
+from gustaf.edges import Edges
 from gustaf.faces import Faces
 from gustaf.helpers.raise_if import ModuleImportRaiser
 from gustaf.volumes import Volumes
@@ -18,26 +19,32 @@ except ModuleNotFoundError as err:
     # from meshio import Mesh as MeshioMesh
 
 
-def load(fname):
+def load(fname, set_boundary=False, return_only_one_mesh=True):
     """Load mesh in meshio format. Loads vertices and their connectivity.
-    Currently cannot process boundary.
 
-    Note
-    -----
-    This is more or less a direct copy from the original gustav implementation.
-    A lot of the meshio information are lost. When boundaries and multi-patch
-    definitions are added this needs to be revisited and extended.
+    The function reads all gustaf-processable element types from meshio, which
+    are sorted by the dimensionality of their element types. Different
+    elements can occur at the same dimensionality, e.g., in mixed meshes,
+    or as sub-topologies, e.g., as boundaries or interfaces.
+
+    If set_boundary is set true, all (d-1)-dimensional submesh node identifiers
+    are assigned to MESH_TYPES.BC without check.
+
+    Return_only_one_mesh ensures compatibility with previous gustaf versions.
 
     Parameters
     ------------
     fname: str | pathlib.Path
+       Input filename
+    set_boundary : bool, optional, default is False
+       Assign nodes of lower-dimensional meshes mesh.BC
+    return_only_one_mesh : bool, optional, default is True
+        Return only the highest-dimensional mesh, ensures compartibility.
 
-    Returns
+    Returns,
     --------
-    MESH_TYPES
+    MESH_TYPES or list(MESH_TYPES)
     """
-    mesh_type = Faces
-
     fname = pathlib.Path(fname)
     if not (fname.exists() and fname.is_file()):
         raise ValueError(
@@ -45,31 +52,62 @@ def load(fname):
             f"{fname.resolve()}"
         )
 
+    # Read mesh
     meshio_mesh: meshio.Mesh = meshio.read(fname)
     vertices = meshio_mesh.points
 
-    # check for 2D mesh
-    # Try for triangle grid
-    cells = meshio_mesh.get_cells_type("triangle")
-    # If  no triangle elements, try for square
-    if len(cells) == 0:
-        cells = meshio_mesh.get_cells_type("quad")
-    if not len(cells) > 0:
-        # 3D mesh
-        mesh_type = Volumes
-        cells = meshio_mesh.get_cells_type("tetra")
-        if len(cells) == 0:
-            cells = meshio_mesh.get_cells_type("hexahedron")
+    # Maps meshio element types to gustaf types and dimensionality
+    # Meshio vertex elements are ommited, as they do not follow gustaf logics
+    meshio_mapping = {
+        "hexahedron": [Volumes, 3],
+        "tetra": [Volumes, 3],
+        "quad": [Faces, 2],
+        "triangle": [Faces, 2],
+        "line": [Edges, 1],
+    }
+    meshes = [
+        [
+            meshio_mapping[key][0](
+                vertices=vertices, elements=meshio_mesh.cells_dict[key]
+            ),
+            meshio_mapping[key][1],
+        ]
+        for key in meshio_mapping.keys()
+        if key in meshio_mesh.cells_dict.keys()
+    ]
+    # Sort by decreasing dimensionality
+    meshes.sort(key=lambda x: -x[1])
 
-    for i, cell in enumerate(cells):
-        if i == 0:
-            elements = cell.data
-        else:
-            elements = np.vstack((elements, cell.data))
+    # Raises exception if the mesh file contains gustaf-incompartible types
+    for elem_type in meshio_mesh.cells_dict.keys():
+        if elem_type not in list(meshio_mapping.keys()) + ["vertex"]:
+            # Be aware that gustaf currently only supports linear element
+            # types.
+            raise NotImplementedError(
+                f"Sorry, {elem_type} elements currently are not supported."
+            )
 
-    mesh = mesh_type(vertices=vertices, elements=elements)
+    set_boundary = True
+    if set_boundary is True:
+        # mesh.BC is only defined for volumes and faces
+        for i in range(len(meshes)):
+            # Indicator for boundary
+            if meshes[i][1] in [3, 2]:
+                for j in range(i, len(meshes)):
+                    # Considers only (d-1)-dimensional subspaces
+                    if meshes[j][1] == meshes[i][1] - 1:
+                        meshes[i][0].BC[
+                            f"{meshes[j][0].whatami}-nodes"
+                        ] = np.unique(meshes[j][0].elements)
 
-    return mesh
+    # Ensures backwards-compartibility
+    if return_only_one_mesh:
+        # Return highest-dimensional mesh
+        return_value = meshes[0][0]
+    else:
+        return_value = [mesh[0] for mesh in meshes]
+
+    return return_value
 
 
 def export(mesh, fname):

--- a/gustaf/io/meshio.py
+++ b/gustaf/io/meshio.py
@@ -19,29 +19,6 @@ except ModuleNotFoundError as err:
     # from meshio import Mesh as MeshioMesh
 
 
-def parse_gmsh_physical_groups(meshio_mesh, field_key, field_cell):
-    """[summary]
-
-    Parameters
-    ----------
-    meshio_mesh : meshio._mesh.Mesh
-    field_key : str
-       Key of field data
-    field_cell : array-like
-       Tuple of field data, commonly [field_id, element_dimension]
-
-    Returns
-    -------
-    array-like
-        IDs of vertices in physical group
-    """
-    # Find nodes in physical groups in gmsh msh2 and msh4 format
-    return np.argwhere(
-        meshio_mesh.cell_data["gmsh:physical"][field_cell[1] - 1]
-        == field_cell[0]
-    )
-
-
 def load(fname, set_boundary=False, return_only_one_mesh=True):
     """Load mesh in meshio format. Loads vertices and their connectivity.
 
@@ -54,6 +31,8 @@ def load(fname, set_boundary=False, return_only_one_mesh=True):
     are assigned to MESH_TYPES.BC without check.
 
     Return_only_one_mesh ensures compatibility with previous gustaf versions.
+
+    Loading physical groups is not supported yet.
 
     Parameters
     ------------
@@ -115,30 +94,6 @@ def load(fname, set_boundary=False, return_only_one_mesh=True):
         for i in range(len(meshes)):
             # Indicator for boundary
             if meshes[i][1] in [3, 2]:
-                # Process field data
-                for field_key, field_cell in meshio_mesh.field_data.items():
-                    if field_cell[1] == meshes[i][1] - 1:
-                        try:
-                            meshes[i][0].BC[field_key] = np.unique(
-                                meshio_mesh.cells[field_cell[0]].data
-                            )
-                        except IndexError:
-                            try:
-                                # The mesh might be in gmsh msh2 / msh4 format,
-                                # try to read this old fromat
-                                meshes[i][0].BC[field_key] = np.unique(
-                                    parse_gmsh_physical_groups(
-                                        meshio_mesh, field_key, field_cell
-                                    )
-                                )
-                            except KeyError or IndexError:
-                                raise (
-                                    """
-                                    The meshio field data could not be
-                                    processed, try deactivating 'set_boundary'.
-                                    """
-                                )
-
                 for j in range(i, len(meshes)):
                     # Considers only (d-1)-dimensional subspaces
                     if meshes[j][1] == meshes[i][1] - 1:


### PR DESCRIPTION
This pull requests proposes an extension of the `meshio.load` function. 
Many mesh formats, including gmsh, include lower-dimensional (boundary) entities in their representation. Thus, a tetraeder grid in gmsh contains not only volumetric surface, but also bounding triangles, lines and even vertices. 
The current implementation assumes face elements (`io/meshio.py` l. 39) and thus ignores all volumetric elements. 

The suggested way to change this, is considering all gustaf-compatible element-types present in the meshio mesh, which currently include hexahedrons, tetraeder, triangles, quads and lines. Meshio also supports non-linear element types, whose presence raises an exception. 

The extended function not only represents all mesh dimensions, but also returns lower-dimensional submeshes, if `return_only_one_mesh=False`. This parameter was introduced for backwards-compatibility. 

In addition, the  function, with `set_boundary=True` saves the node ID of boundary nodes to `mesh.BC`. As far as I understood, this is the current handling of boundary conditions for mixd in gustaf. 

Obviously, I will upload the mentioned example files, however, I did not figure out how to add it, yet.

*Example* 
```
import gustaf
fname = '3DBrickTetra.msh'
meshes = gustaf.io.meshio.load(fname, set_boundary=True, return_only_one_mesh=False)

```

Supportive material can be found in https://github.com/tataratat/samples/pull/3
