### PR TITLE
Add quotation marks around gustaf[all]

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install gustaf
 ```
 To install all the [optional dependencies](#optional-dependencies) at the same time, you can use:
 ```
-pip install gustaf[all]
+pip install "gustaf[all]"
 ```
 For the latest develop version of gustaf:
 ```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ pip install gustaf
 ```
 To install all the [optional dependencies](#optional-dependencies) at the same time, you can use:
 ```
+# quotation marks required for some shells
 pip install "gustaf[all]"
 ```
 For the latest develop version of gustaf:


### PR DESCRIPTION
Fixed a small issue in the `README.md` file, where the installation of `gustaf` with all dependencies was displayed a little misleadingly as

```bash
pip install gustaf[all]
```
while this for instance does not work on the Mac shell. Instead, it will now be displayed as

```bash
pip install "gustaf[all]"
```
which should work both on Mac and other OS.