### PR TITLE
remove `backend` concept from Options

### DIFF
--- a/docs/source/extra_docs.py
+++ b/docs/source/extra_docs.py
@@ -12,10 +12,8 @@ import gustaf as gus
 if __name__ == "__main__":
     here = os.path.dirname(os.path.abspath(__file__))
 
-    # here = pathlib.Path(__file__).parent.resolve()
     # create md dir
     md_path = os.path.abspath(os.path.join(here, "..", "md"))
-    # (here / "../md").resolve().mkdir(parents=True, exist_ok=True)
     os.makedirs(md_path, exist_ok=True)
 
     # 1. Show options.
@@ -25,19 +23,18 @@ if __name__ == "__main__":
         derived = gus.helpers.options.ShowOption.__subclasses__()
         for cls in derived:
             f.write(f"## {cls.__qualname__}\n\n")
-            for backend, options in cls._valid_options.items():
-                f.write(f"### {backend}\n\n")
-                for option in options.values():
-                    t_str = str(option.allowed_types)
-                    t_str = (
-                        t_str.replace("<class", "")
-                        .replace("'", "")
-                        .replace(">", "")
-                    )
-                    f.write(
-                        f"<details><summary><strong>{option.key}"
-                        "</strong></summary><p>\n"
-                    )
-                    f.write(f"\n{option.description}  \n")
-                    f.write(f"- _allowed types_: {t_str}  \n")
-                    f.write("</p></details> \n\n")
+            for option in cls._valid_options.values():
+                t_str = str(option.allowed_types)
+                t_str = (
+                    t_str.replace("<class", "")
+                    .replace("'", "")
+                    .replace(">", "")
+                )
+                f.write(
+                    f"<details><summary><strong>{option.key}"
+                    "</strong></summary><p>\n"
+                )
+                f.write(f"\n{option.description}  \n")
+                f.write(f"- _allowed types_: {t_str}  \n")
+                f.write(f"- _default_: {option.default}  \n")
+                f.write("</p></details> \n\n")

--- a/examples/create_boxes.py
+++ b/examples/create_boxes.py
@@ -55,7 +55,7 @@ def main():
         backslash=True,
     )
 
-    gus.show.show_vedo(
+    gus.show(
         ["faces-box", mesh_faces_box],
         ["volumes-box", mesh_volumes_box],
         ["faces-triangle", mesh_faces_triangle],

--- a/examples/mixd_to_nutils.py
+++ b/examples/mixd_to_nutils.py
@@ -20,7 +20,7 @@ def main():
     )
     mesh_npz = gus.io.nutils.load("export/export_npz.npz")
 
-    gus.show.show_vedo(
+    gus.show(
         ["gustaf-mesh", mesh],
         ["mixd-mesh", mesh_mixd],
         ["npz-mesh", mesh_npz],

--- a/examples/shrink_elements.py
+++ b/examples/shrink_elements.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     direct_toedges.show_options["as_arrows"] = True
 
     # not the most efficient way, but it is possible.
-    gus.show.show_vedo(
+    gus.show(
         ["v, Volumes", v],
         ["v.shrink()", v.shrink()],
         [

--- a/gustaf/edges.py
+++ b/gustaf/edges.py
@@ -42,7 +42,7 @@ class EdgesShowOption(helpers.options.ShowOption):
 
     _helps = "Edges"
 
-    def _initialize_vedo_showable(self):
+    def _initialize_showable(self):
         """
         Initializes edges as either vedo.Lines or vedo.Arrows
 

--- a/gustaf/faces.py
+++ b/gustaf/faces.py
@@ -39,7 +39,7 @@ class FacesShowOption(helpers.options.ShowOption):
 
     _helps = "Faces"
 
-    def _initialize_vedo_showable(self):
+    def _initialize_showable(self):
         """
         Initializes Faces as vedo.Mesh
 

--- a/gustaf/helpers/__init__.py
+++ b/gustaf/helpers/__init__.py
@@ -1,6 +1,7 @@
-from gustaf.helpers import data, raise_if
+from gustaf.helpers import data, options, raise_if
 
 __all__ = [
     "data",
+    "options",
     "raise_if",
 ]

--- a/gustaf/helpers/options.py
+++ b/gustaf/helpers/options.py
@@ -10,20 +10,59 @@ from gustaf import settings
 class Option:
     """
     Minimal Class to hold each options. Mainly to replace nested dict.
+
+    Parameters
+    ----------
+    backends: set
+      set of strings.
+    key: str
+    description: str
+    allowed_types: set
+      set of types
+    default: one of allwed_types
+      Optional. Default is None
     """
 
     __slots__ = (
-        "backend",
+        "backends",
         "key",
         "description",
         "allowed_types",
+        "default",
     )
 
-    def __init__(self, backend, key, description, allowed_types):
-        self.backend = backend
-        self.key = key
-        self.description = description
-        self.allowed_types = allowed_types
+    def __init__(
+        self, backends, key, description, allowed_types, default=None
+    ):
+        """
+        Check types
+        """
+        if isinstance(backends, str):
+            self.backends = {backends}
+        elif getattr(backends, "__iter__", False):
+            self.backends = set(backends)
+        else:
+            raise TypeError("Invalid backends type")
+
+        if isinstance(key, str):
+            self.key = key
+        else:
+            raise TypeError("Invalid key type")
+
+        if isinstance(description, str):
+            self.description = description
+        else:
+            raise TypeError("Invalid description type")
+
+        if isinstance(allowed_types, (tuple, list, set)):
+            self.allowed_types = set(allowed_types)
+        else:
+            raise TypeError("Invalid allowed_types type")
+
+        if default is None or default in self.allowed_types:
+            self.default = default
+        else:
+            raise TypeError("Invalid default type")
 
     def __repr__(self):
         specific = "\n".join(

--- a/gustaf/helpers/options.py
+++ b/gustaf/helpers/options.py
@@ -4,6 +4,8 @@ Classes to help organize options.
 """
 from copy import deepcopy
 
+from gustaf.helpers.raise_if import ModuleImportRaiser
+
 
 class Option:
     """
@@ -198,6 +200,15 @@ def make_valid_options(*options):
     for opt in options:
         if isinstance(opt, Option):
             # copy option object to avoid overwriting defaults
+            # only exception is if this option is a backend object
+            # and wrapped by ModuleImportRaiser
+            allowed_types = []
+            for at in opt.allowed_types:
+                if isinstance(at, ModuleImportRaiser):
+                    continue
+                allowed_types.append(at)
+            opt.allowed_types = tuple(allowed_types)
+
             valid_options[opt.key] = deepcopy(opt)
         elif isinstance(opt, SetDefault):
             # overwrite default of existing option.

--- a/gustaf/show.py
+++ b/gustaf/show.py
@@ -6,7 +6,7 @@ import sys
 
 import numpy as np
 
-from gustaf import settings, utils
+from gustaf import utils
 
 # @linux it raises error if vedo is imported inside the function.
 try:
@@ -34,30 +34,7 @@ class _CallableShowDotPy(sys.modules[__name__].__class__):
 sys.modules[__name__].__class__ = _CallableShowDotPy
 
 
-def show(*gus_obj, **kwargs):
-    """Shows using appropriate backend.
-
-    Parameters
-    -----------
-    *gus_obj: gustaf objects
-
-    Returns
-    --------
-    None
-    """
-    vis_b = settings.VISUALIZATION_BACKEND
-
-    if vis_b.startswith("vedo"):
-        return show_vedo(*gus_obj, **kwargs)
-    elif vis_b.startswith("trimesh"):  # noqa: SIM114
-        pass
-    elif vis_b.startswith("matplotlib"):
-        pass
-    else:
-        raise NotImplementedError
-
-
-def show_vedo(
+def show(
     *args,
     **kwargs,
 ):
@@ -164,7 +141,7 @@ def show_vedo(
                 sl = [sl]  # noqa: PLW2901
             for _k, item in enumerate(sl):
                 if hasattr(item, "showable"):
-                    tmp_showable = item.showable(backend="vedo", **kwargs)
+                    tmp_showable = item.showable(**kwargs)
                     # splines return dict
                     # - maybe it is time to do some typing..
                     if isinstance(tmp_showable, dict):
@@ -209,7 +186,7 @@ def show_vedo(
         return plt
 
 
-def _vedo_showable(obj, as_dict=False, **kwargs):
+def make_showable(obj, as_dict=False, **kwargs):
     """Generates a vedo obj based on `kind` attribute from given obj, as well
     as show_options.
 
@@ -381,46 +358,6 @@ def _vedo_showable(obj, as_dict=False, **kwargs):
     else:
         return_as_dict["main"] = vedo_obj
         return return_as_dict
-
-
-def _trimesh_showable(_obj):
-    """"""
-    pass
-
-
-def _matplotlib_showable(_obj):
-    """"""
-    pass
-
-
-def make_showable(obj, backend=settings.VISUALIZATION_BACKEND, **kwargs):
-    """Since gustaf does not natively support visualization, one of the
-    following library is used to visualize gustaf (visualizable) objects: (1)
-    vedo -> Fast, offers a lot of features (2) trimesh -> Fast, compatible with
-    old OpenGL (3) matplotlib -> Slow, offers vector graphics.
-
-    This determines showing types using `whatami`.
-
-    Parameters
-    -----------
-    obj: gustaf-objects
-    backend: str
-      (Optional) Default is `gustaf.settings.VISUALIZATION_BACKEND`.
-      Options are: "vedo" | "trimesh" | "matplotlib"
-
-    Returns
-    --------
-    showable_objs: list
-      List of showable objects.
-    """
-    if backend.startswith("vedo"):
-        return _vedo_showable(obj, **kwargs)
-    elif backend.startswith("trimesh"):
-        return _trimesh_showable(obj, **kwargs)
-    elif backend.startswith("matplotlib"):
-        return _matplotlib_showable(obj, **kwargs)
-    else:
-        raise NotImplementedError
 
 
 # possibly relocate, is this actually used?

--- a/gustaf/vertices.py
+++ b/gustaf/vertices.py
@@ -42,7 +42,7 @@ class VerticesShowOption(helpers.options.ShowOption):
 
     _helps = "Vertices"
 
-    def _initialize_vedo_showable(self):
+    def _initialize_showable(self):
         """
         Initialize Vertices showable for vedo.
 

--- a/gustaf/volumes.py
+++ b/gustaf/volumes.py
@@ -22,7 +22,7 @@ class VolumesShowOption(helpers.options.ShowOption):
 
     _helps = "Volumes"
 
-    def _initialize_vedo_showable(self):
+    def _initialize_showable(self):
         """
         Initialize volumes as vedo.UGrid or visually equivalent vedo.Mesh
 
@@ -68,7 +68,7 @@ class VolumesShowOption(helpers.options.ShowOption):
         faces = self._helpee.to_faces(unique=True)
         self.copy_valid_options(faces.show_options)
 
-        return faces.show_options._initialize_vedo_showable()
+        return faces.show_options._initialize_showable()
 
 
 class Volumes(Faces):

--- a/tests/test_helpers/test_options.py
+++ b/tests/test_helpers/test_options.py
@@ -1,0 +1,19 @@
+import pytest
+
+import gustaf as gus
+
+def sample_option():
+    return gus.helpers.options.Option(
+        "vedo", "color", "color in german is Farbe", (str, tuple, list), "green"
+    )
+
+def test_option_init():
+    op = gus.helpers.options.Option("vedo", "a", "abc", (str, int), "efg")
+    assert "vedo" in op.backends
+    assert op.key == "a"
+    assert op.description == "abc"
+    assert op.allowed_types == set(str, int)
+    assert op.default == "efg"
+
+def test_option_type_check():
+    pass

--- a/tests/test_helpers/test_options.py
+++ b/tests/test_helpers/test_options.py
@@ -1,19 +1,85 @@
 import pytest
 
-import gustaf as gus
+from gustaf.helpers import options
 
-def sample_option():
-    return gus.helpers.options.Option(
-        "vedo", "color", "color in german is Farbe", (str, tuple, list), "green"
-    )
+
+def backend():
+    return "vedo"
+
+
+def key():
+    return "color"
+
+
+def description():
+    return "color in german is Farbe"
+
+
+def types():
+    return (str, tuple, list)
+
+
+def default():
+    return "green"
+
+
+def option():
+    return options.Option(backend(), key(), description(), types(), default())
+
 
 def test_option_init():
-    op = gus.helpers.options.Option("vedo", "a", "abc", (str, int), "efg")
-    assert "vedo" in op.backends
-    assert op.key == "a"
-    assert op.description == "abc"
-    assert op.allowed_types == set(str, int)
-    assert op.default == "efg"
+    op = option()
+    assert backend() in op.backends
+    assert op.key == key()
+    assert op.description == description()
+    assert op.allowed_types == types()
+    assert op.default == default()
+
 
 def test_option_type_check():
-    pass
+    wrong_type_default = 1
+    assert type(wrong_type_default) not in types()
+
+    with pytest.raises(TypeError):
+        options.Option(1, key(), description(), types(), default())
+    with pytest.raises(TypeError):
+        options.Option(backend(), 1, description(), types(), default())
+    with pytest.raises(TypeError):
+        options.Option(backend(), key(), 1, types(), default())
+    with pytest.raises(TypeError):
+        options.Option(backend(), key(), description(), 1, default())
+    with pytest.raises(TypeError):
+        options.Option(
+            backend(), key(), description(), types(), wrong_type_default
+        )
+
+
+def test_make_valid_options():
+    option0 = option()
+    option1 = options.Option(
+        "backend", "key", "description", (int, float), 100
+    )
+    valid_opt = options.make_valid_options(
+        option0,
+        option1,
+    )
+
+    # vo should make a deepcopy
+    assert id(valid_opt[option0.key]) != id(option0)
+    assert id(valid_opt[option1.key]) != id(option1)
+
+    o1_default = -100
+    valid_opt_default_overwrite = options.make_valid_options(
+        option0, option1, options.SetDefault(option1.key, o1_default)
+    )
+
+    assert valid_opt_default_overwrite[option1.key].default == o1_default
+    # o0 default stays the same
+    assert valid_opt_default_overwrite[option0.key].default == default()
+
+    with pytest.raises(TypeError):
+        valid_opt_default_overwrite = options.make_valid_options(
+            option0,
+            option1,
+            options.SetDefault(option1.key, "str is not allowed"),
+        )


### PR DESCRIPTION
- for compatibility, kept backend argument (renamed to backends).
- added option for specifying default
- added tests