### PR TITLE
No more safe copy and less copy based on wrong modification tracking.

### DIFF
--- a/gustaf/edges.py
+++ b/gustaf/edges.py
@@ -85,7 +85,6 @@ class Edges(Vertices):
         vertices=None,
         edges=None,
         elements=None,
-        copy=True,
     ):
         """Edges. It has vertices and edges. Also known as lines.
 
@@ -94,7 +93,7 @@ class Edges(Vertices):
         vertices: (n, d) np.ndarray
         edges: (n, 2) np.ndarray
         """
-        super().__init__(vertices=vertices, copy=copy)
+        super().__init__(vertices=vertices)
 
         if edges is not None:
             self.edges = edges
@@ -132,7 +131,7 @@ class Edges(Vertices):
         self._logd("setting edges")
 
         self._edges = helpers.data.make_tracked_array(
-            es, settings.INT_DTYPE, self.setter_copies
+            es, settings.INT_DTYPE, copy=False
         )
 
         # shape check

--- a/gustaf/faces.py
+++ b/gustaf/faces.py
@@ -97,7 +97,6 @@ class Faces(Edges):
         vertices=None,
         faces=None,
         elements=None,
-        copy=True,
     ):
         """Faces. It has vertices and faces. Faces could be triangles or
         quadrilaterals.
@@ -107,7 +106,7 @@ class Faces(Edges):
         vertices: (n, d) np.ndarray
         faces: (n, 3) or (n, 4) np.ndarray
         """
-        super().__init__(vertices=vertices, copy=copy)
+        super().__init__(vertices=vertices)
         if faces is not None:
             self.faces = faces
 
@@ -176,9 +175,7 @@ class Faces(Edges):
             )
 
     @property
-    def faces(
-        self,
-    ):
+    def faces(self):
         """Returns faces.
 
         Parameters
@@ -209,7 +206,7 @@ class Faces(Edges):
         self._faces = helpers.data.make_tracked_array(
             fs,
             settings.INT_DTYPE,
-            self.setter_copies,
+            copy=False,
         )
         # shape check
         if fs is not None:

--- a/gustaf/vertices.py
+++ b/gustaf/vertices.py
@@ -90,7 +90,6 @@ class Vertices(GustafBase):
         "_const_vertices",
         "_computed",
         "_show_options",
-        "_setter_copies",
         "_vertex_data",
     )
 
@@ -100,22 +99,18 @@ class Vertices(GustafBase):
     def __init__(
         self,
         vertices=None,
-        copy=True,
     ):
         """Vertices. It has vertices.
 
         Parameters
         -----------
         vertices: (n, d) np.ndarray
-        copy: bool
-          If false, all setter calls will try to avoid copy.
 
         Returns
         --------
         None
         """
         # call setters
-        self.setter_copies = copy
         self.vertices = vertices
 
         # init helpers
@@ -156,8 +151,9 @@ class Vertices(GustafBase):
         """
         self._logd("setting vertices")
 
+        # we try not to make copy.
         self._vertices = helpers.data.make_tracked_array(
-            vs, settings.FLOAT_DTYPE, self.setter_copies
+            vs, settings.FLOAT_DTYPE, copy=False
         )
 
         # shape check
@@ -207,39 +203,6 @@ class Vertices(GustafBase):
         return self._vertex_data
 
     @property
-    def setter_copies(self):
-        """
-        Switch to set if setter should copy or try to avoid copying.
-        If data is np.ndarray, c_contiguous, and has same dtype as
-        corresponding settings.<FLOAT/INT>_dtype, it can probably avoid being
-        copied. Setter will try to cast input to bool.
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        setter_copies: bool
-        """
-        return self._setter_copies
-
-    @setter_copies.setter
-    def setter_copies(self, should_copy):
-        """
-        Sets setter_copies
-
-        Parameters
-        ----------
-        should_copy: bool
-
-        Returns
-        -------
-        None
-        """
-        self._setter_copies = bool(should_copy)
-
-    @property
     def show_options(self):
         """
         Returns a show option manager for this object. Behaves similar to
@@ -256,22 +219,6 @@ class Vertices(GustafBase):
         """
         self._logd("returning show_options")
         return self._show_options
-
-    @property
-    def vis_dict(self):
-        """
-        Temporary backward compatibility
-        """
-        self._logw("`vis_dict` is deprecated. Please use `show_options`")
-        return self.show_options
-
-    @vis_dict.setter
-    def vis_dict(self, vd):
-        """
-        Tmp
-        """
-        self._logw("`vis_dict` is deprecated. Please use `show_options`")
-        self._show_options = vd
 
     @property
     def whatami(self):

--- a/gustaf/volumes.py
+++ b/gustaf/volumes.py
@@ -98,7 +98,6 @@ class Volumes(Faces):
         vertices=None,
         volumes=None,
         elements=None,
-        copy=True,
     ):
         """Volumes. It has vertices and volumes. Volumes could be tetrahedrons
         or hexahedrons.
@@ -108,7 +107,7 @@ class Volumes(Faces):
         vertices: (n, d) np.ndarray
         volumes: (n, 4) or (n, 8) np.ndarray
         """
-        super().__init__(vertices=vertices, copy=copy)
+        super().__init__(vertices=vertices)
         if volumes is not None:
             self.volumes = volumes
         elif elements is not None:
@@ -192,7 +191,7 @@ class Volumes(Faces):
         self._volumes = helpers.data.make_tracked_array(
             vols,
             settings.INT_DTYPE,
-            self.setter_copies,
+            copy=False,
         )
         if vols is not None:
             utils.arr.is_one_of_shapes(


### PR DESCRIPTION
fixes #170, #144

used to make safe copies during init, but it tends to create unnecessary overhead. 