### PR TITLE
add support for UGrid name change

### DIFF
--- a/gustaf/show.py
+++ b/gustaf/show.py
@@ -11,6 +11,14 @@ from gustaf import utils
 # @linux it raises error if vedo is imported inside the function.
 try:
     import vedo
+
+    # class name UGrid is deprecated since 2023.5.0
+    # After *.5.1 release, we could remove this part by bumping min. version
+    # requirement
+    if vedo.__version__ < "2023.5.0":
+        vedoUGrid = vedo.UGrid
+    else:
+        vedoUGrid = vedo.UnstructuredGrid
 except ImportError as err:
     # overwrites the vedo module with an object which will throw an error
     # as soon as it is used the first time. This means that any non vedo
@@ -20,6 +28,7 @@ except ImportError as err:
     from gustaf.helpers.raise_if import ModuleImportRaiser
 
     vedo = ModuleImportRaiser("vedo", err)
+    vedoUGrid = vedo
 
 
 # enable `gus.show()`

--- a/gustaf/volumes.py
+++ b/gustaf/volumes.py
@@ -46,7 +46,7 @@ class VolumesShowOption(helpers.options.ShowOption):
 
             to_vtktype = {"tet": frau_tetra, "hexa": herr_hexa}
             grid_type = to_vtktype[self._helpee.whatami]
-            u_grid = show.vedo.UGrid(
+            u_grid = show.vedoUGrid(
                 [
                     self._helpee.const_vertices,
                     self._helpee.const_volumes,


### PR DESCRIPTION
Sets correct alias to UGrid / UnstructuredGrid based on `vedo` version