### PR TITLE
Ft: remove splinepy ipynb example

### DIFF
--- a/examples/ipynb/notebook_showcase_k3d.ipynb
+++ b/examples/ipynb/notebook_showcase_k3d.ipynb
@@ -123,90 +123,7 @@
    "source": [
     "## `splinepy` plotting examples\n",
     "\n",
-    "Now let's turn up the heat with splines.\n",
-    "\n",
-    "You will need to install splinepy into the environment that you are using as kernel for this notebook."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import splinepy"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's first create some splines. For this example, we will create two tori."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "torus = splinepy.helpme.create.torus(\n",
-    "    torus_radius=4,\n",
-    "    section_outer_radius=1\n",
-    ")\n",
-    "torus.control_points += [3, 0, 3]\n",
-    "\n",
-    "empty_torus = splinepy.helpme.create.circle(1).create.revolved([0, 1, 0], [3, 0, 0], 360)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You might want to limit number of lines to show, as it seems to be very expensive to prepare for notebooks. For splines, knot lines and control mesh are shown as lines: we turn them off for this plot."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "torus.show_options[\"knots\"] = False\n",
-    "torus.show_options[\"control_mesh\"] = False\n",
-    "torus.show_options[\"c\"] = \"hotpink\"\n",
-    "empty_torus.show_options[\"knots\"] = False\n",
-    "empty_torus.show_options[\"control_mesh\"] = False\n",
-    "\n",
-    "gus.show([torus, empty_torus])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Have you heard of spline composition? With this method, you can create spline based microstructures in exact fashion. This is one of the highlights of the `splinepy`. For more information, please take a look at splinepy's [docs](https://tataratat.github.io/splinepy/_generated/splinepy.bezier.BezierBase.compose.html#splinepy.bezier.BezierBase.compose)\n",
-    "\n",
-    "Creating microstructures require two ingredients: outer spline (also known as deformation function, outer function, ...) and a microtile. For this example, we will use empty torus as outer spline and 2d cross as microtile (see other available ready-to-use microtiles [here](https://tataratat.github.io/splinepy/_generated/splinepy.microstructure.tiles.html))."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "donut = splinepy.microstructure.Microstructure(\n",
-    "    deformation_function=empty_torus,\n",
-    "    tiling=[3, 3],\n",
-    "    microtile=splinepy.microstructure.tiles.Cross2D(),\n",
-    ")\n",
-    "donut.show(\n",
-    "    control_points=False,\n",
-    "    knots=False,\n",
-    "    scalarbar=False,\n",
-    "    lightning=\"off\",\n",
-    ")"
+    "It is also possible to plot splines through this gustaf extension. Please check out the examples in the [`splinepy`](https://www.github.com/tataratat/splinepy) library."
    ]
   }
  ],
@@ -226,7 +143,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I was not sure if we should remove the splinepy example from the gustaf ipynb example.

Pro (keep it):
Better visibility of splinepy from another package

Con (remove it):
Additional dependency people have to install to run the example
Example of something that is not even part of the package itself

I am personally ok with keeping it in, but wanted to give you all the option to weigh in with your opinions.