### PR TITLE
Setting setting offscreen default & enable running of example on headless server

### DIFF
--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -1,0 +1,34 @@
+name: test examples
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  test_examples:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+      - name: enable headless render
+        run: |
+            sudo apt-get update
+            sudo apt-get install -y libgl1-mesa-glx libgl1-mesa-dev xvfb --no_install_recommends
+            set -x
+            export DISPLAY=:99.0
+            Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+            set +x
+            exec "$@"
+      - name: Set up python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.10
+
+      - name: install gustaf
+        run: |
+            pip install .[dev]
+      - name: run examples
+        run: |
+            cd examples
+            python3 run_all_examples.py

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up python 3.10
         uses: actions/setup-python@v3
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: install gustaf
         run: |

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -14,7 +14,7 @@ jobs:
       - name: enable headless render
         run: |
             sudo apt-get update
-            sudo apt-get install -y libgl1-mesa-glx libgl1-mesa-dev xvfb --no_install_recommends
+            sudo apt-get install -y libgl1-mesa-glx libgl1-mesa-dev xvfb
             set -x
             export DISPLAY=:99.0
             Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -1,7 +1,7 @@
 name: test examples
 
 on:
-  push:
+  pull_request:
     branches: ["main"]
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,3 @@ jobs:
       run: |
         python3 -m pip install pytest
         pytest tests
-
-    - name: check examples
-      run: |
-        python3 examples/run_all_examples.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,3 +30,7 @@ jobs:
       run: |
         python3 -m pip install pytest
         pytest tests
+
+    - name: check examples
+      run: |
+        python3 examples/run_all_examples.py

--- a/examples/create_boxes.py
+++ b/examples/create_boxes.py
@@ -33,7 +33,7 @@ diagonalization in the other direction.
 import gustaf as gus
 
 
-def main():
+def example():
     mesh_faces_box = gus.create.faces.box(
         bounds=[[0, 0], [2, 2]], resolutions=[2, 3]
     )
@@ -65,4 +65,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    example()

--- a/examples/export_meshio.py
+++ b/examples/export_meshio.py
@@ -4,7 +4,8 @@ import numpy as np
 
 import gustaf as gus
 
-if __name__ == "__main__":
+
+def example():
     export_path = Path("export")
 
     # define coordinates
@@ -55,3 +56,7 @@ if __name__ == "__main__":
     # Export only tetrahedra
     gus.io.meshio.export(tet, export_path / "export_meshio.vtu")
     gus.io.meshio.export(tet.to_faces(), export_path / "export_meshio.stl")
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/interfaces/nutils_interface.py
+++ b/examples/interfaces/nutils_interface.py
@@ -14,7 +14,7 @@ from nutils.expression_v2 import Namespace
 import gustaf as gus
 
 
-def main():
+def example():
     # Simulation parameters
     degree = 1
     btype = "std"
@@ -143,4 +143,4 @@ def define_mesh():
 
 
 if __name__ == "__main__":
-    main()
+    example()

--- a/examples/interfaces/nutils_interface.py
+++ b/examples/interfaces/nutils_interface.py
@@ -80,7 +80,7 @@ def example():
     deformation = lhs.reshape(m.vertices.shape)
     m.vertices += deformation
 
-    gus.show.show_vedo(
+    gus.show.show(
         [m_in, "gustaf_input-mesh"],
         [m, "gustaf_mesh-with-lhs"],
         [gustaf_mesh, "gustaf_mesh-bezier"],

--- a/examples/mixd_to_nutils.py
+++ b/examples/mixd_to_nutils.py
@@ -3,7 +3,7 @@ import numpy as np
 import gustaf as gus
 
 
-def main():
+def example():
     # Creates a gustaf volume.
     mesh = create_mesh()
 
@@ -63,4 +63,4 @@ def create_mesh():
 
 
 if __name__ == "__main__":
-    main()
+    example()

--- a/examples/run_all_examples.py
+++ b/examples/run_all_examples.py
@@ -2,24 +2,60 @@
 """
 
 import glob
+import importlib
+import os
 import pathlib
-import subprocess
 import sys
 
-if __name__ == "__main__":
-    files_not_completed = []
+import gustaf
 
-    for file in glob.glob(str(pathlib.Path(__file__).parent) + "/*.py"):
-        if file.split("/")[-1] in [
+if __name__ == "__main__":
+    gustaf.settings.DEFAULT_OFFSCREEN = True
+    files_not_completed = []
+    examples_root_dir = pathlib.Path(__file__).parent.absolute()
+    current_dir = pathlib.Path(os.getcwd()).absolute()
+
+    for file_ in glob.glob(str(examples_root_dir) + "/*.py"):
+        if file_.split("/")[-1] in [
             "run_all_examples.py",
             "load_sample_file.py",
         ]:
+            continue  # i like pathlib so i convert the path into it
+        file = pathlib.Path(file_)
+        print(
+            f"file: {file}",
+            f"file.parent: {file.parent}",
+            f"current_dir: {current_dir}",
+            f"file.stem: {file.stem}",
+        )
+        # change directory to the file's directory so that imports are
+        # relative to the file's directory
+        os.chdir(file.parent)
+        # ignore this file
+        if "run_all_examples.py" in str(file):
             continue
         print(f"Calling {file}")
+        # import and call the file
         try:
-            proc_return = subprocess.run([sys.executable, file], check=True)
-        except subprocess.CalledProcessError:
+            # add the file's directory to the path so importlib can
+            # import it
+            sys.path.insert(0, f"{file.parent}{os.sep}")
+            example = importlib.import_module(file.stem)
+        except Exception as e:
+            print(f"Failed to import {file}.")
+            print(f"Error: {e}")
             files_not_completed.append(file)
+            continue
+        try:
+            # run example
+            example.example()
+        except Exception as e:
+            print(f"Failed to call {file}.")
+            print(f"Error: {e}")
+            files_not_completed.append(file)
+            continue
+        # change directory back to the original directory
+        os.chdir(current_dir)
     if len(files_not_completed) > 0:
         print(
             f"Failed to call {len(files_not_completed)} files: "

--- a/examples/show_edges.py
+++ b/examples/show_edges.py
@@ -2,7 +2,8 @@ import numpy as np
 
 import gustaf as gus
 
-if __name__ == "__main__":
+
+def example():
     # define coordinates
     v = np.array(
         [
@@ -42,3 +43,7 @@ if __name__ == "__main__":
 
     # show
     edges.show()
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/show_faces.py
+++ b/examples/show_faces.py
@@ -2,7 +2,8 @@ import numpy as np
 
 import gustaf as gus
 
-if __name__ == "__main__":
+
+def example():
     # define coordinates
     v = np.array(
         [
@@ -60,3 +61,7 @@ if __name__ == "__main__":
     # show
     tri.show()
     quad.show()
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/show_gmsh.py
+++ b/examples/show_gmsh.py
@@ -11,7 +11,8 @@ import load_sample_file
 import gustaf
 from gustaf import io
 
-if __name__ == "__main__":
+
+def example():
     mesh_file_tri = pathlib.Path("faces/tri/2DChannelTria.msh")
     mesh_file_quad = pathlib.Path("faces/quad/2DChannelQuad.msh")
     mesh_file_tetra = pathlib.Path("volumes/tet/3DBrickTet.msh")
@@ -39,3 +40,7 @@ if __name__ == "__main__":
         *[[msh.__class__.__name__, msh] for msh in loaded_mesh_default],
         title="3D mesh with tetrahedrons",
     )
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/show_scalarbar.py
+++ b/examples/show_scalarbar.py
@@ -2,7 +2,8 @@ import numpy as np
 
 import gustaf as gus
 
-if __name__ == "__main__":
+
+def example():
     f = gus.Faces()
     f.vertices = [
         [1.16670818, 0.116044],
@@ -223,3 +224,7 @@ if __name__ == "__main__":
         "nlabels": 12,
     }
     gus.show.show([f, "3D scalarbar"], [f_2d, "2D scalarbar"])
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/show_vertices.py
+++ b/examples/show_vertices.py
@@ -2,7 +2,8 @@ import numpy as np
 
 import gustaf as gus
 
-if __name__ == "__main__":
+
+def example():
     # define coordinates
     v = np.array(
         [
@@ -27,3 +28,7 @@ if __name__ == "__main__":
     vert.show_options["r"] = 10
     vert.show_options["vertex_ids"] = True
     vert.show()
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/show_volumes.py
+++ b/examples/show_volumes.py
@@ -2,7 +2,8 @@ import numpy as np
 
 import gustaf as gus
 
-if __name__ == "__main__":
+
+def example():
     # define coordinates
     v = np.array(
         [
@@ -55,3 +56,7 @@ if __name__ == "__main__":
     # set vertex_data to plot
     hexa.show_options["data"] = "arange"
     hexa.show()
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/shrink_elements.py
+++ b/examples/shrink_elements.py
@@ -1,6 +1,7 @@
 import gustaf as gus
 
-if __name__ == "__main__":
+
+def example():
     # create 2x3x4 test hexa element
     v_res = [2, 3, 4]
     vertices = gus.create.vertices.raster(
@@ -37,3 +38,7 @@ if __name__ == "__main__":
             direct_toedges,
         ],
     )
+
+
+if __name__ == "__main__":
+    example()

--- a/gustaf/settings.py
+++ b/gustaf/settings.py
@@ -19,3 +19,7 @@ VEDO_DEFAULT_OPTIONS = {
 }
 
 NTHREADS = 1
+
+DEFAULT_OFFSCREEN = False
+#: If True, the visualization will default to offscreen. This is useful for
+#: running tests on CI/CD servers.

--- a/gustaf/show.py
+++ b/gustaf/show.py
@@ -7,7 +7,7 @@ import sys
 
 import numpy as np
 
-from gustaf import utils
+from gustaf import settings, utils
 
 try:
     from gustaf.helpers.notebook import K3DPlotterN
@@ -70,7 +70,7 @@ def show(*args, **kwargs):
     """
     # vedo plotter parameter
     N = len(args)
-    offs = kwargs.get("offscreen", False)
+    offs = kwargs.get("offscreen", settings.DEFAULT_OFFSCREEN)
     interact = kwargs.get("interactive", True)
     plt = kwargs.get("vedoplot", None)
     skip_clear = kwargs.get("skip_clear", False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ test = [
     "pytest",
     "funi>=0.0.1",
     "napf>=0.0.5",
+    "vedo>=2023.5.0",
 ]
 dev = [
     "pytest",


### PR DESCRIPTION
To enable running the examples in CI/CD to also test them in every PR automatically we need to have vedo run offscreen. To enable this the gustaf setting `gustaf.settings.DEFAULT_OFFSCREEN` is added. This is used in `gustaf.show.show` as the default option for the kwarg `offscreen`.

If you set this option to `True` in the beginning of a script and don't overwrite the kwarg in the call to show every vedo show is offscreen.

Further the script `example/run_all_examples.py` now is able to run all examples with this option enabled. On my PC it works without problem.

*Disclaimer*
I have not tested this on a headless server so we might have to tweak it further for it to actually work.