### PR TITLE
Cu mixd io / typo fixes

### DIFF
--- a/gustaf/helpers/options.py
+++ b/gustaf/helpers/options.py
@@ -275,7 +275,7 @@ class ShowOption(HelperBase):
         description: str
         """
         valid_and_current = []
-        for vo in self._valid_option.values():
+        for vo in self._valid_options.values():
             valid = str(vo)
             current = ""
             if vo.key in self.keys():

--- a/gustaf/io/mixd.py
+++ b/gustaf/io/mixd.py
@@ -90,9 +90,7 @@ def load(
     # boundary conditions
     bcs = {}
     try:
-        bcs_in = np.fromfile(mrng, dtype="_big_endian_int").astype(
-            np.int32
-        )  # flattened
+        bcs_in = np.fromfile(mrng, dtype=_big_endian_int).astype(np.int32)
         uniq_bcs_in = np.unique(bcs_in)
         uniq_bcs_in = uniq_bcs_in[uniq_bcs_in > 0]  # keep only natural nums
         sub_elem_ids = np.arange(bcs_in.size)


### PR DESCRIPTION
This PR create an internal-use function to write a big endian file. It doesn't need to be part of API, just useful if you have extra arrays to export, e.g., `mprd`.

Also, typo fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the iteration over dictionary values for improved consistency in configuration handling.

- **New Features**
  - Standardized endianness handling for reading and writing data in mesh files.
  - Introduced helper functions for array manipulation and optimized file writing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->