### PR TITLE
add arrow_data_to_origin option

### DIFF
--- a/examples/show_faces.py
+++ b/examples/show_faces.py
@@ -58,5 +58,17 @@ if __name__ == "__main__":
     )
 
     # show
-    tri.show()
-    quad.show()
+    gus.show(["triangles", tri], ["quads", quad])
+
+    # plot data - plots vector data as arrows
+    for mesh in [tri, quad]:
+        mesh.vertex_data["coords"] = np.random.default_rng().random(
+            tri.vertices.shape
+        )
+        mesh.show_options(arrow_data="coords")
+    gus.show(["triangles", tri], ["quads", quad])
+
+    # point data to origin
+    for mesh in [tri, quad]:
+        mesh.show_options(arrow_data_to_origin=True)
+    gus.show(["triangles", tri], ["quads", quad])

--- a/gustaf/helpers/options.py
+++ b/gustaf/helpers/options.py
@@ -153,7 +153,7 @@ vedo_common_options = (
         "dict with following items are accepted: "
         "{title: str, pos: tuple, size: list, title_font: str, "
         "title_xoffset: float, title_yoffset: float, title_size: float, "
-        "title_rotation: float, nlabels: int, label_font:str, "
+        "title_rotation: float, nlabels: int, label_font: str, "
         "label_size: float, label_offset: float, label_rotation: int, "
         "label_format: str, draw_box: bool, above_text: str, below_text: str, "
         "nan_text: str, categories: list}",
@@ -179,6 +179,13 @@ vedo_common_options = (
         "Color for arrow data. Can be either cmap name or color. For "
         "cmap, colors are based on the size of the arrows.",
         (str, tuple, list, int),
+    ),
+    Option(
+        "vedo",
+        "arrow_data_to_origin",
+        "Points arrow data to geometric origin."
+        "Equivalent to shifting arrows backwards with their own magitudes.",
+        (bool,),
     ),
     Option(
         "vedo",

--- a/gustaf/show.py
+++ b/gustaf/show.py
@@ -367,10 +367,11 @@ def make_showable(obj, as_dict=False, **kwargs):
 
         # we are here because this data is not a scalar
         # is showable?
-        if arrow_data_value.shape[1] not in (2, 3):
+        a_data_dim = arrow_data_value.shape[1]
+        if a_data_dim not in (2, 3):
             raise ValueError(
                 "Only 2D or 3D data can be shown.",
-                f"Requested data is {arrow_data_value.shape[1]}",
+                f"Requested data is {a_data_dim}D.",
             )
 
         as_edges = from_data(
@@ -379,6 +380,16 @@ def make_showable(obj, as_dict=False, **kwargs):
             obj.show_options.get("arrow_data_scale", None),
             data_norm=obj.vertex_data.as_scalar(arrow_data),
         )
+
+        if obj.show_options.get("arrow_data_to_origin", False):
+            # point arrow to the origin instead
+            arrow_shift = np.diff(
+                as_edges.vertices.reshape(-1, 2, a_data_dim), axis=1
+            )
+            as_edges.vertices[:] = (
+                as_edges.vertices.reshape(-1, 2, a_data_dim) - arrow_shift
+            ).reshape(-1, a_data_dim)
+
         arrows = vedo.Arrows(
             as_edges.vertices[as_edges.edges],
             c=obj.show_options.get("arrow_data_color", "plasma"),


### PR DESCRIPTION
Adds option to point arrow to origin. For example:
```
*: origin
<-: destination

Default:
<--------*

arrow_data_to_origin=True:
         *<--------
```