### PR TITLE
Update github api for pip upload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - name: build wheels and sdist
         run: pipx run build
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./dist/*
 
@@ -21,7 +21,7 @@ jobs:
     needs: [wheel_build_full]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,9 @@ classifiers = [
 ]
 dependencies = [
     "numpy",
+    "packaging",
 ]
+
 dynamic = ["version"]
 
 [project.readme]


### PR DESCRIPTION
The github v3 api for `upload-artifact` and `download-artifact` is deprecated and removed. We need to update this. This seems to be, in our case, a drop in replacement. 

Sources:
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/


@j042 Is there a way setup to try this out before PR into main?